### PR TITLE
fix(proxy): inject stream_options for OpenAI streaming usage tracking

### DIFF
--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -69,9 +69,10 @@ pub async fn chat_completions<S: Storage + 'static>(
         // Ensure OpenAI-compatible providers include token usage in the final
         // streaming chunk. Harmlessly ignored by Anthropic/Google/Bedrock which
         // build their own request format and don't read `extra`.
-        request.extra.entry("stream_options".to_string()).or_insert(
-            serde_json::json!({ "include_usage": true }),
-        );
+        request
+            .extra
+            .entry("stream_options".to_string())
+            .or_insert(serde_json::json!({ "include_usage": true }));
 
         // Streaming: retry + fallback on connection errors only (pre-stream).
         let mut last_err = None;


### PR DESCRIPTION
## Summary

- Inject `stream_options: { include_usage: true }` into streaming requests so OpenAI-compatible providers include token usage in the final SSE chunk
- Without this, `UsageTracker` and `Budget` extensions never see usage data for streaming requests — silently skipping billing
- Injection happens once in the handler layer (zero clones), uses `entry` API to respect client-provided values
- Harmlessly ignored by Anthropic/Google/Bedrock which build their own request formats

## Phases completed

- [x] Inject `stream_options` in handler before streaming dispatch
- [x] Verified Azure coverage (same `.json(request)` path)
- [x] Verified Google Gemini already includes `usage_metadata` in streaming — no change needed
- [x] Verified Anthropic already reports usage in `message_delta` — no change needed

Closes #10