### PR TITLE
feat(proxy): add Prometheus metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +133,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +262,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -282,6 +318,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -353,6 +398,7 @@ dependencies = [
  "crabllm-llamacpp",
  "crabllm-provider",
  "crabllm-proxy",
+ "metrics-exporter-prometheus",
  "reqwest",
  "serde_json",
  "tokio",
@@ -421,6 +467,7 @@ dependencies = [
  "crabllm-provider",
  "dashmap",
  "futures",
+ "metrics",
  "rand 0.9.2",
  "redis",
  "reqwest",
@@ -456,6 +503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -570,6 +626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +738,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +772,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -855,6 +929,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1073,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1002,6 +1096,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1206,6 +1301,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1424,53 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1608,6 +1760,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1803,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,7 +1831,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1679,7 +1852,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1780,6 +1953,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,7 +2020,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1936,6 +2127,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1943,6 +2135,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1961,6 +2165,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2167,6 +2372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,7 +2471,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2342,7 +2553,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2379,7 +2590,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -2403,7 +2614,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -2494,11 +2705,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3105,6 +3336,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,7 +3746,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,5 @@ flate2 = "1"
 tar = "0.4"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 dirs = "6"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -34,3 +34,4 @@ reqwest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
+metrics-exporter-prometheus.workspace = true

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -198,7 +198,7 @@ async fn run<S: Storage + 'static>(
     storage: Arc<S>,
     mut llama_servers: Vec<crabllm_provider::LlamaCppServer>,
 ) {
-    let (extensions, admin_routes) =
+    let (extensions, mut admin_routes) =
         match build_extensions(&config, storage.clone() as Arc<dyn Storage>) {
             Ok(result) => result,
             Err(e) => {
@@ -206,6 +206,15 @@ async fn run<S: Storage + 'static>(
                 std::process::exit(1);
             }
         };
+
+    // Install Prometheus metrics recorder and expose /metrics endpoint.
+    let handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install metrics recorder");
+    admin_routes.push(axum::Router::new().route(
+        "/metrics",
+        axum::routing::get(move || async move { handle.render() }),
+    ));
 
     let ext_count = extensions.len();
     let addr = config.listen.clone();

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 uuid.workspace = true
 sha2.workspace = true
 rand.workspace = true
+metrics.workspace = true
 
 # optional
 redis = { workspace = true, optional = true }

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -15,8 +15,51 @@ use crabllm_core::{
 use crabllm_provider::Deployment;
 use futures::StreamExt;
 use rand::Rng;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
+
+fn record_duration(ctx: &RequestContext, status: &'static str) {
+    metrics::histogram!("crabllm_request_duration_seconds",
+        "provider" => ctx.provider.clone(),
+        "model" => ctx.model.clone(),
+        "status" => status,
+        "stream" => if ctx.is_stream { "true" } else { "false" },
+    )
+    .record(ctx.started_at.elapsed().as_secs_f64());
+}
+
+fn error_status(e: &crabllm_core::Error) -> &'static str {
+    match e {
+        crabllm_core::Error::Provider { status, .. } => match status {
+            429 => "429",
+            400..=499 => "4xx",
+            _ => "5xx",
+        },
+        _ => "5xx",
+    }
+}
+
+fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
+    if prompt > 0 {
+        metrics::counter!("crabllm_tokens_total",
+            "provider" => ctx.provider.clone(),
+            "model" => ctx.model.clone(),
+            "direction" => "prompt",
+        )
+        .increment(prompt as u64);
+    }
+    if completion > 0 {
+        metrics::counter!("crabllm_tokens_total",
+            "provider" => ctx.provider.clone(),
+            "model" => ctx.model.clone(),
+            "direction" => "completion",
+        )
+        .increment(completion as u64);
+    }
+}
 
 /// POST /v1/chat/completions
 pub async fn chat_completions<S: Storage + 'static>(
@@ -81,18 +124,33 @@ pub async fn chat_completions<S: Storage + 'static>(
                 Ok(stream) => {
                     let extensions = state.extensions.clone();
                     let ctx = Arc::new(ctx);
+                    let errored = Arc::new(AtomicBool::new(false));
+
+                    let ctx_done = ctx.clone();
+                    let errored_done = errored.clone();
 
                     let observed = stream.then(move |result| {
                         let extensions = extensions.clone();
                         let ctx = ctx.clone();
+                        let errored = errored.clone();
                         async move {
                             match &result {
                                 Ok(chunk) => {
+                                    // Token usage arrives in the final chunk when
+                                    // the provider supports stream_options.include_usage.
+                                    if let Some(ref usage) = chunk.usage {
+                                        record_tokens(
+                                            &ctx,
+                                            usage.prompt_tokens,
+                                            usage.completion_tokens,
+                                        );
+                                    }
                                     for ext in extensions.iter() {
                                         ext.on_chunk(&ctx, chunk).await;
                                     }
                                 }
                                 Err(error) => {
+                                    errored.store(true, Ordering::Relaxed);
                                     for ext in extensions.iter() {
                                         ext.on_error(&ctx, error).await;
                                     }
@@ -117,7 +175,14 @@ pub async fn chat_completions<S: Storage + 'static>(
                         }
                     });
 
-                    let done = futures::stream::once(async {
+                    // Record duration once when the stream terminates.
+                    let done = futures::stream::once(async move {
+                        let status = if errored_done.load(Ordering::Relaxed) {
+                            "5xx"
+                        } else {
+                            "2xx"
+                        };
+                        record_duration(&ctx_done, status);
                         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
                     });
                     let full_stream = sse_stream.chain(done);
@@ -135,9 +200,12 @@ pub async fn chat_completions<S: Storage + 'static>(
         for ext in state.extensions.iter() {
             ext.on_error(&ctx, &e).await;
         }
+        record_duration(&ctx, "5xx");
         error_response(e)
     } else {
         // Non-streaming: check cache first.
+        // Cache hits skip duration recording — sub-millisecond responses
+        // would skew the histogram, which should reflect provider latency.
         for ext in state.extensions.iter() {
             if let Some(cached) = ext.on_cache_lookup(&request).await {
                 return Json(cached).into_response();
@@ -148,6 +216,10 @@ pub async fn chat_completions<S: Storage + 'static>(
         for deployment in &deployments {
             match try_chat_with_retries(deployment, &state.client, &request).await {
                 Ok(resp) => {
+                    if let Some(ref usage) = resp.usage {
+                        record_tokens(&ctx, usage.prompt_tokens, usage.completion_tokens);
+                    }
+                    record_duration(&ctx, "2xx");
                     for ext in state.extensions.iter() {
                         ext.on_response(&ctx, &request, &resp).await;
                     }
@@ -162,6 +234,7 @@ pub async fn chat_completions<S: Storage + 'static>(
         for ext in state.extensions.iter() {
             ext.on_error(&ctx, &e).await;
         }
+        record_duration(&ctx, error_status(&e));
         error_response(e)
     }
 }
@@ -216,7 +289,10 @@ pub async fn embeddings<S: Storage + 'static>(
     let mut last_err = None;
     for deployment in &deployments {
         match try_embedding_with_retries(deployment, &state.client, &request).await {
-            Ok(resp) => return Json(resp).into_response(),
+            Ok(resp) => {
+                record_duration(&ctx, "2xx");
+                return Json(resp).into_response();
+            }
             Err(e) => last_err = Some(e),
         }
     }
@@ -226,6 +302,7 @@ pub async fn embeddings<S: Storage + 'static>(
     for ext in state.extensions.iter() {
         ext.on_error(&ctx, &e).await;
     }
+    record_duration(&ctx, error_status(&e));
     error_response(e)
 }
 
@@ -306,6 +383,7 @@ pub async fn image_generations<S: Storage + 'static>(
         .await
         {
             Ok((bytes, content_type)) => {
+                record_duration(&ctx, "2xx");
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -317,6 +395,7 @@ pub async fn image_generations<S: Storage + 'static>(
     for ext in state.extensions.iter() {
         ext.on_error(&ctx, &e).await;
     }
+    record_duration(&ctx, error_status(&e));
     error_response(e)
 }
 
@@ -376,6 +455,7 @@ pub async fn audio_speech<S: Storage + 'static>(
         .await
         {
             Ok((bytes, content_type)) => {
+                record_duration(&ctx, "2xx");
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -387,6 +467,7 @@ pub async fn audio_speech<S: Storage + 'static>(
     for ext in state.extensions.iter() {
         ext.on_error(&ctx, &e).await;
     }
+    record_duration(&ctx, error_status(&e));
     error_response(e)
 }
 
@@ -524,6 +605,7 @@ pub async fn audio_transcriptions<S: Storage + 'static>(
         .await
         {
             Ok((bytes, content_type)) => {
+                record_duration(&ctx, "2xx");
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -535,6 +617,7 @@ pub async fn audio_transcriptions<S: Storage + 'static>(
     for ext in state.extensions.iter() {
         ext.on_error(&ctx, &e).await;
     }
+    record_duration(&ctx, error_status(&e));
     error_response(e)
 }
 

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -1,5 +1,8 @@
 use axum::{
-    Json, Router, middleware,
+    Json, Router,
+    extract::Request,
+    middleware,
+    response::Response,
     routing::{get, post},
 };
 use crabllm_core::Storage;
@@ -12,6 +15,16 @@ pub mod ext;
 mod handlers;
 mod state;
 pub mod storage;
+
+/// Middleware that tracks the number of in-flight API requests.
+/// For SSE streams, the gauge decrements when the response starts (not when the
+/// stream ends), so it undercounts long-lived streaming connections.
+async fn track_active_connections(request: Request, next: middleware::Next) -> Response {
+    metrics::gauge!("crabllm_active_connections").increment(1.0);
+    let response = next.run(request).await;
+    metrics::gauge!("crabllm_active_connections").decrement(1.0);
+    response
+}
 
 /// Build the Axum router with all API routes and admin routes.
 pub fn router<S: Storage + 'static>(state: AppState<S>, admin_routes: Vec<Router>) -> Router {
@@ -35,6 +48,7 @@ pub fn router<S: Storage + 'static>(state: AppState<S>, admin_routes: Vec<Router
             state.clone(),
             auth::auth::<S>,
         ))
+        .layer(middleware::from_fn(track_active_connections))
         .with_state(state);
 
     // Health check — outside auth middleware so load balancers can probe it.


### PR DESCRIPTION
## Summary

- Expose `GET /metrics` (Prometheus text format) outside auth middleware
- Three metrics: `crabllm_request_duration_seconds` (histogram), `crabllm_tokens_total` (counter), `crabllm_active_connections` (gauge)
- All five API handlers instrumented with duration histogram; token counters on chat completions (streaming + non-streaming)

`crabllm_requests_total` omitted — redundant with histogram `_count`. `crabllm_provider_errors_total` omitted — derivable from histogram's status label (429/4xx/5xx).

Closes #12