### PR TITLE
refactor(provider): type-system-first Provider trait dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ name = "crabllm-core"
 version = "0.0.12"
 dependencies = [
  "bytes",
+ "futures-core",
  "serde",
  "serde_json",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
 name = "crabllm-core"
 version = "0.0.12"
 dependencies = [
+ "bytes",
  "serde",
  "serde_json",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,6 @@ name = "crabllm"
 version = "0.0.12"
 dependencies = [
  "axum",
- "bytes",
  "clap",
  "crabllm-core",
  "crabllm-provider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "axum",
  "clap",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-bench"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "axum",
  "clap",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-core"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bytes",
  "futures-core",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-provider"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-proxy"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "axum",
  "bytes",
@@ -1457,7 +1457,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamars"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "axum",
  "clap",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-bench"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "axum",
  "clap",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-core"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "bytes",
  "futures-core",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-provider"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-proxy"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "axum",
  "bytes",
@@ -1457,7 +1457,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamars"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,13 +411,13 @@ name = "crabllm"
 version = "0.0.12"
 dependencies = [
  "axum",
+ "bytes",
  "clap",
  "crabllm-core",
  "crabllm-provider",
  "crabllm-proxy",
  "llamars",
  "metrics-exporter-prometheus",
- "reqwest",
  "serde_json",
  "tokio",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ axum = { version = "0.8", features = ["multipart"] }
 bytes = "1"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
+futures-core = "0.3"
 reqwest = { version = "0.13", default-features = false, features = ["json", "multipart", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "High-performance LLM API gateway"
@@ -12,13 +12,13 @@ keywords = ["llm", "gateway", "proxy", "openai", "anthropic"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [workspace.dependencies]
-crabllm-core = { version = "0.0.12", path = "crates/core" }
-crabllm-provider = { version = "0.0.12", path = "crates/provider" }
-crabllm-proxy = { version = "0.0.12", path = "crates/proxy" }
-crabllm-bench = { version = "0.0.12", path = "crates/bench" }
-crabllm = { version = "0.0.12", path = "crates/crabllm" }
-llamars = { version = "0.0.12", path = "crates/llamars" }
-crabllm-llamacpp = { version = "0.0.12", path = "crates/llamars", package = "llamars" }
+crabllm-core = { version = "0.0.13", path = "crates/core" }
+crabllm-provider = { version = "0.0.13", path = "crates/provider" }
+crabllm-proxy = { version = "0.0.13", path = "crates/proxy" }
+crabllm-bench = { version = "0.0.13", path = "crates/bench" }
+crabllm = { version = "0.0.13", path = "crates/crabllm" }
+llamars = { version = "0.0.13", path = "crates/llamars" }
+crabllm-llamacpp = { version = "0.0.13", path = "crates/llamars", package = "llamars" }
 
 # crates-io
 axum = { version = "0.8", features = ["multipart"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.13"
+version = "0.0.14"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "High-performance LLM API gateway"
@@ -12,13 +12,13 @@ keywords = ["llm", "gateway", "proxy", "openai", "anthropic"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [workspace.dependencies]
-crabllm-core = { version = "0.0.13", path = "crates/core" }
-crabllm-provider = { version = "0.0.13", path = "crates/provider" }
-crabllm-proxy = { version = "0.0.13", path = "crates/proxy" }
-crabllm-bench = { version = "0.0.13", path = "crates/bench" }
-crabllm = { version = "0.0.13", path = "crates/crabllm" }
-llamars = { version = "0.0.13", path = "crates/llamars" }
-crabllm-llamacpp = { version = "0.0.13", path = "crates/llamars", package = "llamars" }
+crabllm-core = { version = "0.0.14", path = "crates/core" }
+crabllm-provider = { version = "0.0.14", path = "crates/provider" }
+crabllm-proxy = { version = "0.0.14", path = "crates/proxy" }
+crabllm-bench = { version = "0.0.14", path = "crates/bench" }
+crabllm = { version = "0.0.14", path = "crates/crabllm" }
+llamars = { version = "0.0.14", path = "crates/llamars" }
+crabllm-llamacpp = { version = "0.0.14", path = "crates/llamars", package = "llamars" }
 
 # crates-io
 axum = { version = "0.8", features = ["multipart"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ gateway = ["toml"]
 
 [dependencies]
 # crates-io
+bytes.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml = { workspace = true, optional = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ gateway = ["toml"]
 [dependencies]
 # crates-io
 bytes.workspace = true
+futures-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml = { workspace = true, optional = true }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -41,6 +41,14 @@ impl Error {
             _ => false,
         }
     }
+
+    /// Build an "operation not supported" error for a provider trait method
+    /// that has no implementation. Used by `Provider` trait default impls.
+    /// Distinct from per-provider rejection messages so log lines can be
+    /// disambiguated by grep.
+    pub fn not_implemented(method: &str) -> Self {
+        Error::Internal(format!("provider method '{method}' not implemented"))
+    }
 }
 
 impl std::error::Error for Error {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@ pub use config::{
 };
 pub use error::{ApiError, ApiErrorBody, Error};
 pub use extension::{Extension, ExtensionError, RequestContext};
+pub use provider::{BoxStream, Provider};
 pub use storage::{BoxFuture, KvPairs, PREFIX_LEN, Prefix, Storage, storage_key};
 pub use types::{
     AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice,
@@ -15,5 +16,6 @@ pub use types::{
 mod config;
 mod error;
 mod extension;
+mod provider;
 mod storage;
 mod types;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,8 +8,8 @@ pub use types::{
     AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice,
     ChunkChoice, CompletionTokensDetails, Delta, Embedding, EmbeddingInput, EmbeddingRequest,
     EmbeddingResponse, EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef,
-    ImageRequest, Message, Model, ModelList, Role, Stop, Tool, ToolCall, ToolCallDelta, ToolChoice,
-    ToolType, Usage,
+    ImageRequest, Message, Model, ModelList, MultipartField, Role, Stop, Tool, ToolCall,
+    ToolCallDelta, ToolChoice, ToolType, Usage,
 };
 
 mod config;

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -41,9 +41,7 @@ pub trait Provider: Send + Sync {
     fn chat_completion_stream(
         &self,
         request: &ChatCompletionRequest,
-    ) -> impl Future<
-        Output = Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error>,
-    > + Send;
+    ) -> impl Future<Output = Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error>> + Send;
 
     fn embedding(
         &self,

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,0 +1,75 @@
+use crate::{
+    AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse,
+    EmbeddingRequest, EmbeddingResponse, Error, ImageRequest, MultipartField,
+};
+use bytes::Bytes;
+use futures_core::Stream;
+use std::{future::Future, pin::Pin};
+
+/// A boxed, `Send`, dynamically-typed stream — used by `Provider` so the
+/// trait can return a uniform stream type without each implementor leaking
+/// its concrete combinator chain through an associated type.
+pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+
+/// The dispatch surface every provider implementation satisfies.
+///
+/// Returns futures via RPITIT (return-position `impl Trait` in trait) so the
+/// type system can monomorphize through the trait without dyn dispatch or
+/// per-call boxing. The proxy crate is generic over `P: Provider`; the binary
+/// crate picks the concrete type by defining a workspace-level union enum
+/// that delegates each method.
+///
+/// Streaming responses use `BoxStream` because returning an opaque stream
+/// from an async-returning trait method requires a fixed type at the trait
+/// boundary; the boxing is one allocation per stream creation, not per item.
+/// **Implementors must clone any borrowed data from the request before
+/// returning the stream** — the returned `BoxStream` is `'static` and cannot
+/// borrow from the request reference.
+///
+/// Default implementations return `Error::not_implemented` so concrete
+/// providers only need to override the methods they actually support. The
+/// default impls intentionally capture neither `self` nor the request,
+/// keeping the returned future `'static` and `Send` regardless of
+/// implementor.
+pub trait Provider: Send + Sync {
+    fn chat_completion(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> impl Future<Output = Result<ChatCompletionResponse, Error>> + Send;
+
+    fn chat_completion_stream(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> impl Future<
+        Output = Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error>,
+    > + Send;
+
+    fn embedding(
+        &self,
+        _request: &EmbeddingRequest,
+    ) -> impl Future<Output = Result<EmbeddingResponse, Error>> + Send {
+        async { Err(Error::not_implemented("embedding")) }
+    }
+
+    fn image_generation(
+        &self,
+        _request: &ImageRequest,
+    ) -> impl Future<Output = Result<(Bytes, String), Error>> + Send {
+        async { Err(Error::not_implemented("image_generation")) }
+    }
+
+    fn audio_speech(
+        &self,
+        _request: &AudioSpeechRequest,
+    ) -> impl Future<Output = Result<(Bytes, String), Error>> + Send {
+        async { Err(Error::not_implemented("audio_speech")) }
+    }
+
+    fn audio_transcription(
+        &self,
+        _model: &str,
+        _fields: &[MultipartField],
+    ) -> impl Future<Output = Result<(Bytes, String), Error>> + Send {
+        async { Err(Error::not_implemented("audio_transcription")) }
+    }
+}

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -26,11 +26,12 @@ pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
 /// returning the stream** — the returned `BoxStream` is `'static` and cannot
 /// borrow from the request reference.
 ///
-/// Default implementations return `Error::not_implemented` so concrete
-/// providers only need to override the methods they actually support. The
-/// default impls intentionally capture neither `self` nor the request,
-/// keeping the returned future `'static` and `Send` regardless of
-/// implementor.
+/// The optional methods (`embedding`, `image_generation`, `audio_speech`,
+/// `audio_transcription`) default to returning `Error::not_implemented`, so
+/// concrete providers only override the methods they actually support.
+/// Overrides are free to capture `self` or the request reference — only the
+/// default impl bodies happen to capture nothing, and that's an
+/// implementation detail of the defaults, not a constraint on the trait.
 pub trait Provider: Send + Sync {
     fn chat_completion(
         &self,

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -2,9 +2,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 // ── Enums ──
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Role {
-    #[default]
     User,
     Assistant,
     System,
@@ -199,7 +198,7 @@ pub enum Stop {
     Multiple(Vec<String>),
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -215,6 +214,35 @@ pub struct Message {
     #[serde(flatten, default)]
     #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl Message {
+    fn with_role(role: Role, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: Some(serde_json::Value::String(content.into())),
+            tool_calls: None,
+            tool_call_id: None,
+            name: None,
+            reasoning_content: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    /// Build a `Message` with role `User` and the given text content.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self::with_role(Role::User, content)
+    }
+
+    /// Build a `Message` with role `Assistant` and the given text content.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self::with_role(Role::Assistant, content)
+    }
+
+    /// Build a `Message` with role `System` and the given text content.
+    pub fn system(content: impl Into<String>) -> Self {
+        Self::with_role(Role::System, content)
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -266,7 +294,7 @@ pub struct ChatCompletionResponse {
     pub system_fingerprint: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Choice {
     pub index: u32,
     pub message: Message,

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 // ── Enums ──
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum Role {
+    #[default]
     User,
     Assistant,
     System,
@@ -198,7 +199,7 @@ pub enum Stop {
     Multiple(Vec<String>),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -252,7 +253,7 @@ pub struct FunctionDef {
 
 // ── Response ──
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ChatCompletionResponse {
     pub id: String,
     pub object: String,
@@ -265,7 +266,7 @@ pub struct ChatCompletionResponse {
     pub system_fingerprint: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Choice {
     pub index: u32,
     pub message: Message,
@@ -296,7 +297,7 @@ pub struct CompletionTokensDetails {
 
 // ── Streaming ──
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ChatCompletionChunk {
     pub id: String,
     pub object: String,
@@ -309,7 +310,7 @@ pub struct ChatCompletionChunk {
     pub system_fingerprint: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ChunkChoice {
     pub index: u32,
     pub delta: Delta,
@@ -319,7 +320,7 @@ pub struct ChunkChoice {
     pub logprobs: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Delta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<Role>,

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -217,7 +217,7 @@ pub struct Message {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<u32>,
@@ -227,13 +227,13 @@ pub struct ToolCall {
     pub function: FunctionCall,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct FunctionCall {
     pub name: String,
     pub arguments: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Tool {
     #[serde(rename = "type")]
     pub kind: ToolType,
@@ -242,7 +242,7 @@ pub struct Tool {
     pub strict: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct FunctionDef {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -9,9 +9,11 @@ pub use embedding::{
 };
 pub use image::ImageRequest;
 pub use model::{Model, ModelList};
+pub use multipart::MultipartField;
 
 mod audio;
 mod chat;
 mod embedding;
 mod image;
 mod model;
+mod multipart;

--- a/crates/core/src/types/multipart.rs
+++ b/crates/core/src/types/multipart.rs
@@ -1,0 +1,12 @@
+use bytes::Bytes;
+
+/// A buffered multipart form field. Carries name, filename, content type, and
+/// bytes across the provider trait boundary without depending on any HTTP
+/// client crate.
+#[derive(Debug, Clone)]
+pub struct MultipartField {
+    pub name: String,
+    pub filename: Option<String>,
+    pub content_type: Option<String>,
+    pub bytes: Bytes,
+}

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -30,7 +30,6 @@ crabllm-proxy.workspace = true
 
 # crates-io
 axum.workspace = true
-bytes.workspace = true
 clap.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -30,8 +30,8 @@ crabllm-proxy.workspace = true
 
 # crates-io
 axum.workspace = true
+bytes.workspace = true
 clap.workspace = true
-reqwest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -1,10 +1,5 @@
-use bytes::Bytes;
 use clap::{Parser, Subcommand};
-use crabllm_core::{
-    AudioSpeechRequest, BoxStream, ChatCompletionChunk, ChatCompletionRequest,
-    ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse, Error, Extension, GatewayConfig,
-    ImageRequest, MultipartField, Provider, Storage,
-};
+use crabllm_core::{Extension, GatewayConfig, Storage};
 use crabllm_provider::{ProviderRegistry, RemoteProvider};
 use crabllm_proxy::{
     AppState,
@@ -20,75 +15,6 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
-
-/// Workspace-level union of every provider type the binary links.
-///
-/// `crabllm-proxy` is generic over `P: Provider` and gets monomorphized
-/// against this enum at the binary boundary. Adding a new provider source
-/// (e.g. an in-process inference backend) means adding a variant here and
-/// a delegation arm in the `impl Provider for Dispatch` below — the
-/// provider crate stays untouched.
-#[derive(Debug, Clone)]
-pub enum Dispatch {
-    Remote(RemoteProvider),
-}
-
-impl Provider for Dispatch {
-    async fn chat_completion(
-        &self,
-        request: &ChatCompletionRequest,
-    ) -> Result<ChatCompletionResponse, Error> {
-        match self {
-            Dispatch::Remote(p) => p.chat_completion(request).await,
-        }
-    }
-
-    async fn chat_completion_stream(
-        &self,
-        request: &ChatCompletionRequest,
-    ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error> {
-        match self {
-            Dispatch::Remote(p) => p.chat_completion_stream(request).await,
-        }
-    }
-
-    async fn embedding(
-        &self,
-        request: &EmbeddingRequest,
-    ) -> Result<EmbeddingResponse, Error> {
-        match self {
-            Dispatch::Remote(p) => p.embedding(request).await,
-        }
-    }
-
-    async fn image_generation(
-        &self,
-        request: &ImageRequest,
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Dispatch::Remote(p) => p.image_generation(request).await,
-        }
-    }
-
-    async fn audio_speech(
-        &self,
-        request: &AudioSpeechRequest,
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Dispatch::Remote(p) => p.audio_speech(request).await,
-        }
-    }
-
-    async fn audio_transcription(
-        &self,
-        model: &str,
-        fields: &[MultipartField],
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Dispatch::Remote(p) => p.audio_transcription(model, fields).await,
-        }
-    }
-}
 
 #[derive(Parser)]
 #[command(name = "crabllm", about = "High-performance LLM API gateway")]
@@ -285,8 +211,8 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
         }
     };
 
-    let registry: ProviderRegistry<Dispatch> =
-        match ProviderRegistry::from_config(&config, Dispatch::Remote) {
+    let registry: ProviderRegistry<RemoteProvider> =
+        match ProviderRegistry::from_config(&config, |r| r) {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("error: failed to build provider registry: {e}");
@@ -353,7 +279,7 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
 
 async fn run<S: Storage + 'static>(
     config: GatewayConfig,
-    registry: ProviderRegistry<Dispatch>,
+    registry: ProviderRegistry<RemoteProvider>,
     storage: Arc<S>,
 ) {
     let (extensions, mut admin_routes) =
@@ -406,7 +332,7 @@ async fn run<S: Storage + 'static>(
         ));
     }
 
-    let state: AppState<S, Dispatch> = AppState {
+    let state: AppState<S, RemoteProvider> = AppState {
         registry,
         config,
         extensions: Arc::new(extensions),

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -1,6 +1,11 @@
+use bytes::Bytes;
 use clap::{Parser, Subcommand};
-use crabllm_core::{Extension, GatewayConfig, Storage};
-use crabllm_provider::ProviderRegistry;
+use crabllm_core::{
+    AudioSpeechRequest, BoxStream, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse, Error, Extension, GatewayConfig,
+    ImageRequest, MultipartField, Provider, Storage,
+};
+use crabllm_provider::{ProviderRegistry, RemoteProvider};
 use crabllm_proxy::{
     AppState,
     ext::{
@@ -15,6 +20,75 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
+
+/// Workspace-level union of every provider type the binary links.
+///
+/// `crabllm-proxy` is generic over `P: Provider` and gets monomorphized
+/// against this enum at the binary boundary. Adding a new provider source
+/// (e.g. an in-process inference backend) means adding a variant here and
+/// a delegation arm in the `impl Provider for Dispatch` below — the
+/// provider crate stays untouched.
+#[derive(Debug, Clone)]
+pub enum Dispatch {
+    Remote(RemoteProvider),
+}
+
+impl Provider for Dispatch {
+    async fn chat_completion(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, Error> {
+        match self {
+            Dispatch::Remote(p) => p.chat_completion(request).await,
+        }
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error> {
+        match self {
+            Dispatch::Remote(p) => p.chat_completion_stream(request).await,
+        }
+    }
+
+    async fn embedding(
+        &self,
+        request: &EmbeddingRequest,
+    ) -> Result<EmbeddingResponse, Error> {
+        match self {
+            Dispatch::Remote(p) => p.embedding(request).await,
+        }
+    }
+
+    async fn image_generation(
+        &self,
+        request: &ImageRequest,
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            Dispatch::Remote(p) => p.image_generation(request).await,
+        }
+    }
+
+    async fn audio_speech(
+        &self,
+        request: &AudioSpeechRequest,
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            Dispatch::Remote(p) => p.audio_speech(request).await,
+        }
+    }
+
+    async fn audio_transcription(
+        &self,
+        model: &str,
+        fields: &[MultipartField],
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            Dispatch::Remote(p) => p.audio_transcription(model, fields).await,
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "crabllm", about = "High-performance LLM API gateway")]
@@ -211,13 +285,14 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
         }
     };
 
-    let registry = match ProviderRegistry::from_config(&config) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("error: failed to build provider registry: {e}");
-            std::process::exit(1);
-        }
-    };
+    let registry: ProviderRegistry<Dispatch> =
+        match ProviderRegistry::from_config(&config, Dispatch::Remote) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error: failed to build provider registry: {e}");
+                std::process::exit(1);
+            }
+        };
 
     let storage_kind = config
         .storage
@@ -278,7 +353,7 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
 
 async fn run<S: Storage + 'static>(
     config: GatewayConfig,
-    registry: ProviderRegistry,
+    registry: ProviderRegistry<Dispatch>,
     storage: Arc<S>,
 ) {
     let (extensions, mut admin_routes) =
@@ -331,12 +406,8 @@ async fn run<S: Storage + 'static>(
         ));
     }
 
-    let state = AppState {
+    let state: AppState<S, Dispatch> = AppState {
         registry,
-        client: reqwest::Client::builder()
-            .tcp_nodelay(true)
-            .build()
-            .expect("failed to build HTTP client"),
         config,
         extensions: Arc::new(extensions),
         storage,

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -51,18 +51,24 @@ pub enum RemoteProvider {
 }
 
 /// Build the shared `reqwest::Client` used by every `RemoteProvider`
-/// variant. `tcp_nodelay(true)` matches the gateway's inbound listener and
-/// avoids Nagle-buffering small SSE writes on the proxy → upstream hop.
-fn make_client() -> reqwest::Client {
+/// instance. `tcp_nodelay(true)` matches the gateway's inbound listener
+/// and avoids Nagle-buffering small SSE writes on the proxy → upstream
+/// hop. Called once at registry construction and the result is cloned
+/// into every `RemoteProvider`, so all providers share a single
+/// connection pool, DNS resolver, and TLS state.
+pub(crate) fn make_client() -> reqwest::Client {
     reqwest::Client::builder()
         .tcp_nodelay(true)
         .build()
         .expect("crabllm: failed to build reqwest client")
 }
 
-impl From<&ProviderConfig> for RemoteProvider {
-    fn from(config: &ProviderConfig) -> Self {
-        let client = make_client();
+impl RemoteProvider {
+    /// Build a `RemoteProvider` from a `ProviderConfig`, reusing a shared
+    /// `reqwest::Client`. Cloning the client is cheap — internally it's
+    /// `Arc<ClientRef>` — so every provider returned by this constructor
+    /// dispatches through the same connection pool.
+    pub fn new(config: &ProviderConfig, client: reqwest::Client) -> Self {
         match config.kind {
             ProviderKind::Openai => RemoteProvider::Openai {
                 client,

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -262,17 +262,16 @@ impl Provider for RemoteProvider {
         }
     }
 
-    async fn embedding(
-        &self,
-        request: &EmbeddingRequest,
-    ) -> Result<EmbeddingResponse, Error> {
+    async fn embedding(&self, request: &EmbeddingRequest) -> Result<EmbeddingResponse, Error> {
         match self {
             RemoteProvider::Openai {
                 client,
                 base_url,
                 api_key,
             } => provider::openai::embedding(client, base_url, api_key, request).await,
-            RemoteProvider::Anthropic { .. } => Err(provider::anthropic::not_implemented("embedding")),
+            RemoteProvider::Anthropic { .. } => {
+                Err(provider::anthropic::not_implemented("embedding"))
+            }
             RemoteProvider::Google { .. } => Err(provider::google::not_implemented("embedding")),
             RemoteProvider::Bedrock { .. } => Err(provider::bedrock::not_implemented("embedding")),
             RemoteProvider::Azure {
@@ -284,10 +283,7 @@ impl Provider for RemoteProvider {
         }
     }
 
-    async fn image_generation(
-        &self,
-        request: &ImageRequest,
-    ) -> Result<(Bytes, String), Error> {
+    async fn image_generation(&self, request: &ImageRequest) -> Result<(Bytes, String), Error> {
         match self {
             RemoteProvider::Openai {
                 client,
@@ -315,10 +311,7 @@ impl Provider for RemoteProvider {
         }
     }
 
-    async fn audio_speech(
-        &self,
-        request: &AudioSpeechRequest,
-    ) -> Result<(Bytes, String), Error> {
+    async fn audio_speech(&self, request: &AudioSpeechRequest) -> Result<(Bytes, String), Error> {
         match self {
             RemoteProvider::Openai {
                 client,

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -68,8 +68,12 @@ impl RemoteProvider {
     /// `reqwest::Client`. Cloning the client is cheap — internally it's
     /// `Arc<ClientRef>` — so every provider returned by this constructor
     /// dispatches through the same connection pool.
+    ///
+    /// Routes via [`ProviderConfig::effective_kind`] so a config with
+    /// `kind = "openai"` and a `base_url` containing "anthropic" auto-upgrades
+    /// to the Anthropic dispatch path.
     pub fn new(config: &ProviderConfig, client: reqwest::Client) -> Self {
-        match config.kind {
+        match config.effective_kind() {
             ProviderKind::Openai => RemoteProvider::Openai {
                 client,
                 base_url: config

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -63,6 +63,30 @@ pub(crate) fn make_client() -> reqwest::Client {
         .expect("crabllm: failed to build reqwest client")
 }
 
+/// Strip known endpoint suffixes so users can paste either a bare origin
+/// (`https://api.openai.com/v1`) or a full endpoint URL
+/// (`https://api.openai.com/v1/chat/completions`) and get the same result.
+///
+/// Only the OpenAI-shaped endpoints are stripped: `/chat/completions`,
+/// `/embeddings`, `/audio/transcriptions`, `/audio/speech`,
+/// `/images/generations`. Anthropic, Google, and Bedrock don't take a
+/// `base_url` field at all, so this function is never called for them.
+fn normalize_base_url(url: &str) -> String {
+    let url = url.trim_end_matches('/');
+    for suffix in [
+        "/chat/completions",
+        "/embeddings",
+        "/audio/transcriptions",
+        "/audio/speech",
+        "/images/generations",
+    ] {
+        if let Some(stripped) = url.strip_suffix(suffix) {
+            return stripped.to_string();
+        }
+    }
+    url.to_string()
+}
+
 impl RemoteProvider {
     /// Build a `RemoteProvider` from a `ProviderConfig`, reusing a shared
     /// `reqwest::Client`. Cloning the client is cheap — internally it's
@@ -71,15 +95,19 @@ impl RemoteProvider {
     ///
     /// Routes via [`ProviderConfig::effective_kind`] so a config with
     /// `kind = "openai"` and a `base_url` containing "anthropic" auto-upgrades
-    /// to the Anthropic dispatch path.
+    /// to the Anthropic dispatch path. Base URLs are normalized so a pasted
+    /// full endpoint URL (e.g. `…/v1/chat/completions`) collapses to the bare
+    /// origin (`…/v1`).
     pub fn new(config: &ProviderConfig, client: reqwest::Client) -> Self {
         match config.effective_kind() {
             ProviderKind::Openai => RemoteProvider::Openai {
                 client,
-                base_url: config
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                base_url: normalize_base_url(
+                    &config
+                        .base_url
+                        .clone()
+                        .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                ),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
             ProviderKind::Anthropic => RemoteProvider::Anthropic {
@@ -92,15 +120,17 @@ impl RemoteProvider {
             },
             ProviderKind::Ollama => RemoteProvider::Openai {
                 client,
-                base_url: config
-                    .base_url
-                    .clone()
-                    .unwrap_or_else(|| "http://localhost:11434/v1".to_string()),
+                base_url: normalize_base_url(
+                    &config
+                        .base_url
+                        .clone()
+                        .unwrap_or_else(|| "http://localhost:11434/v1".to_string()),
+                ),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
             ProviderKind::Azure => RemoteProvider::Azure {
                 client,
-                base_url: config.base_url.clone().unwrap_or_default(),
+                base_url: normalize_base_url(&config.base_url.clone().unwrap_or_default()),
                 api_key: config.api_key.clone().unwrap_or_default(),
                 api_version: config
                     .api_version

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -1,62 +1,95 @@
 use bytes::Bytes;
 use crabllm_core::{
-    AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse,
-    EmbeddingRequest, EmbeddingResponse, Error, ImageRequest, ProviderConfig, ProviderKind,
+    AudioSpeechRequest, BoxStream, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse, Error, ImageRequest,
+    MultipartField, Provider, ProviderConfig, ProviderKind,
 };
-use futures::stream::{BoxStream, StreamExt};
+use futures::stream::StreamExt;
 pub use registry::{Deployment, ProviderRegistry};
 
 mod provider;
 mod registry;
 
-/// A configured provider instance, ready to dispatch requests.
+/// A configured remote-API provider, ready to dispatch requests.
+///
+/// Each variant carries a `reqwest::Client` so the provider trait
+/// implementation needs no shared client passed by the caller. Cloning a
+/// `RemoteProvider` is cheap — `reqwest::Client` is internally `Arc`-shared.
 #[derive(Debug, Clone)]
-pub enum Provider {
+pub enum RemoteProvider {
     /// OpenAI-compatible providers (OpenAI, Ollama, vLLM, Groq, etc.).
     /// Request body is forwarded as-is with URL + auth rewrite.
-    Openai { base_url: String, api_key: String },
+    Openai {
+        client: reqwest::Client,
+        base_url: String,
+        api_key: String,
+    },
     /// Anthropic Messages API. Requires request/response translation.
-    Anthropic { api_key: String },
+    Anthropic {
+        client: reqwest::Client,
+        api_key: String,
+    },
     /// Google Gemini API. Requires request/response translation.
-    Google { api_key: String },
+    Google {
+        client: reqwest::Client,
+        api_key: String,
+    },
     /// AWS Bedrock. Requires SigV4 signing + translation.
     Bedrock {
+        client: reqwest::Client,
         region: String,
         access_key: String,
         secret_key: String,
     },
     /// Azure OpenAI. Uses deployment-based URL and api-key header.
     Azure {
+        client: reqwest::Client,
         base_url: String,
         api_key: String,
         api_version: String,
     },
 }
 
-impl From<&ProviderConfig> for Provider {
+/// Build the shared `reqwest::Client` used by every `RemoteProvider`
+/// variant. `tcp_nodelay(true)` matches the gateway's inbound listener and
+/// avoids Nagle-buffering small SSE writes on the proxy → upstream hop.
+fn make_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .tcp_nodelay(true)
+        .build()
+        .expect("crabllm: failed to build reqwest client")
+}
+
+impl From<&ProviderConfig> for RemoteProvider {
     fn from(config: &ProviderConfig) -> Self {
+        let client = make_client();
         match config.kind {
-            ProviderKind::Openai => Provider::Openai {
+            ProviderKind::Openai => RemoteProvider::Openai {
+                client,
                 base_url: config
                     .base_url
                     .clone()
                     .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
-            ProviderKind::Anthropic => Provider::Anthropic {
+            ProviderKind::Anthropic => RemoteProvider::Anthropic {
+                client,
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
-            ProviderKind::Google => Provider::Google {
+            ProviderKind::Google => RemoteProvider::Google {
+                client,
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
-            ProviderKind::Ollama => Provider::Openai {
+            ProviderKind::Ollama => RemoteProvider::Openai {
+                client,
                 base_url: config
                     .base_url
                     .clone()
                     .unwrap_or_else(|| "http://localhost:11434/v1".to_string()),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
-            ProviderKind::Azure => Provider::Azure {
+            ProviderKind::Azure => RemoteProvider::Azure {
+                client,
                 base_url: config.base_url.clone().unwrap_or_default(),
                 api_key: config.api_key.clone().unwrap_or_default(),
                 api_version: config
@@ -64,17 +97,21 @@ impl From<&ProviderConfig> for Provider {
                     .clone()
                     .unwrap_or_else(|| "2024-02-15-preview".to_string()),
             },
-            ProviderKind::Bedrock => Provider::Bedrock {
+            ProviderKind::Bedrock => RemoteProvider::Bedrock {
+                client,
                 region: config.region.clone().unwrap_or_default(),
                 access_key: config.access_key.clone().unwrap_or_default(),
                 secret_key: config.secret_key.clone().unwrap_or_default(),
             },
             ProviderKind::LlamaCpp => {
-                // LlamaCpp providers are constructed after the managed
-                // llama-server process starts and a port is known.
-                // Use base_url if explicitly set (external llama-server),
-                // otherwise this will be overwritten by the process manager.
-                Provider::Openai {
+                // Unreachable at runtime: when the `llamacpp` feature is on,
+                // `spawn_llamacpp_servers` rewrites the config kind to `Openai`
+                // before `from_config` runs. When the feature is off,
+                // `validate_provider` rejects this kind before construction.
+                // This arm exists only so the match stays exhaustive over
+                // `ProviderKind`.
+                RemoteProvider::Openai {
+                    client,
                     base_url: config.base_url.clone().unwrap_or_default(),
                     api_key: String::new(),
                 }
@@ -83,25 +120,47 @@ impl From<&ProviderConfig> for Provider {
     }
 }
 
-impl Provider {
-    /// Send a non-streaming chat completion request.
-    pub async fn chat_completion(
+/// Build a `reqwest::multipart::Form` from the provider-trait-friendly
+/// `MultipartField` representation. Used by the audio-transcription trait
+/// impls so each call rebuilds a fresh form (multipart parts are not
+/// re-usable across attempts).
+fn rebuild_form(fields: &[MultipartField]) -> reqwest::multipart::Form {
+    let mut form = reqwest::multipart::Form::new();
+    for field in fields {
+        let mut part = reqwest::multipart::Part::stream(field.bytes.clone());
+        if let Some(ref filename) = field.filename {
+            part = part.file_name(filename.clone());
+        }
+        if let Some(ref content_type) = field.content_type {
+            part = part
+                .mime_str(content_type)
+                .unwrap_or_else(|_| reqwest::multipart::Part::stream(field.bytes.clone()));
+        }
+        form = form.part(field.name.clone(), part);
+    }
+    form
+}
+
+impl Provider for RemoteProvider {
+    async fn chat_completion(
         &self,
-        client: &reqwest::Client,
         request: &ChatCompletionRequest,
     ) -> Result<ChatCompletionResponse, Error> {
         match self {
-            Provider::Openai { base_url, api_key } => {
-                provider::openai::chat_completion(client, base_url, api_key, request).await
-            }
-            Provider::Anthropic { api_key } => {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => provider::openai::chat_completion(client, base_url, api_key, request).await,
+            RemoteProvider::Anthropic { client, api_key } => {
                 provider::anthropic::chat_completion(client, api_key, request).await
             }
-            Provider::Google { api_key } => {
+            RemoteProvider::Google { client, api_key } => {
                 provider::google::chat_completion(client, api_key, request).await
             }
             #[cfg(feature = "provider-bedrock")]
-            Provider::Bedrock {
+            RemoteProvider::Bedrock {
+                client,
                 region,
                 access_key,
                 secret_key,
@@ -110,8 +169,9 @@ impl Provider {
                     .await
             }
             #[cfg(not(feature = "provider-bedrock"))]
-            Provider::Bedrock { .. } => Err(provider::bedrock::not_implemented("chat")),
-            Provider::Azure {
+            RemoteProvider::Bedrock { .. } => Err(provider::bedrock::not_implemented("chat")),
+            RemoteProvider::Azure {
+                client,
                 base_url,
                 api_key,
                 api_version,
@@ -122,130 +182,22 @@ impl Provider {
         }
     }
 
-    /// Send an embedding request.
-    pub async fn embedding(
+    async fn chat_completion_stream(
         &self,
-        client: &reqwest::Client,
-        request: &EmbeddingRequest,
-    ) -> Result<EmbeddingResponse, Error> {
-        match self {
-            Provider::Openai { base_url, api_key } => {
-                provider::openai::embedding(client, base_url, api_key, request).await
-            }
-            Provider::Anthropic { .. } => Err(provider::anthropic::not_implemented("embedding")),
-            Provider::Google { .. } => Err(provider::google::not_implemented("embedding")),
-            Provider::Bedrock { .. } => Err(provider::bedrock::not_implemented("embedding")),
-            Provider::Azure {
-                base_url,
-                api_key,
-                api_version,
-            } => provider::azure::embedding(client, base_url, api_key, api_version, request).await,
-        }
-    }
-
-    /// Send an image generation request. Returns raw bytes + content-type.
-    pub async fn image_generation(
-        &self,
-        client: &reqwest::Client,
-        request: &ImageRequest,
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Provider::Openai { base_url, api_key } => {
-                provider::openai::image_generation(client, base_url, api_key, request).await
-            }
-            Provider::Anthropic { .. } => {
-                Err(provider::anthropic::not_implemented("image_generation"))
-            }
-            Provider::Google { .. } => Err(provider::google::not_implemented("image_generation")),
-            Provider::Bedrock { .. } => Err(provider::bedrock::not_implemented("image_generation")),
-            Provider::Azure {
-                base_url,
-                api_key,
-                api_version,
-            } => {
-                provider::azure::image_generation(client, base_url, api_key, api_version, request)
-                    .await
-            }
-        }
-    }
-
-    /// Send a text-to-speech request. Returns raw audio bytes + content-type.
-    pub async fn audio_speech(
-        &self,
-        client: &reqwest::Client,
-        request: &AudioSpeechRequest,
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Provider::Openai { base_url, api_key } => {
-                provider::openai::audio_speech(client, base_url, api_key, request).await
-            }
-            Provider::Anthropic { .. } => Err(provider::anthropic::not_implemented("audio_speech")),
-            Provider::Google { .. } => Err(provider::google::not_implemented("audio_speech")),
-            Provider::Bedrock { .. } => Err(provider::bedrock::not_implemented("audio_speech")),
-            Provider::Azure {
-                base_url,
-                api_key,
-                api_version,
-            } => {
-                provider::azure::audio_speech(client, base_url, api_key, api_version, request).await
-            }
-        }
-    }
-
-    /// Send an audio transcription request. Takes a multipart form + model name.
-    /// Returns raw response bytes + content-type.
-    pub async fn audio_transcription(
-        &self,
-        client: &reqwest::Client,
-        model: &str,
-        form: reqwest::multipart::Form,
-    ) -> Result<(Bytes, String), Error> {
-        match self {
-            Provider::Openai { base_url, api_key } => {
-                provider::openai::audio_transcription(client, base_url, api_key, form).await
-            }
-            Provider::Anthropic { .. } => {
-                Err(provider::anthropic::not_implemented("audio_transcription"))
-            }
-            Provider::Google { .. } => {
-                Err(provider::google::not_implemented("audio_transcription"))
-            }
-            Provider::Bedrock { .. } => {
-                Err(provider::bedrock::not_implemented("audio_transcription"))
-            }
-            Provider::Azure {
-                base_url,
-                api_key,
-                api_version,
-            } => {
-                provider::azure::audio_transcription(
-                    client,
-                    base_url,
-                    api_key,
-                    api_version,
-                    model,
-                    form,
-                )
-                .await
-            }
-        }
-    }
-
-    /// Send a streaming chat completion request.
-    /// Returns a boxed async stream of parsed SSE chunks.
-    pub async fn chat_completion_stream(
-        &self,
-        client: &reqwest::Client,
         request: &ChatCompletionRequest,
     ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error> {
         match self {
-            Provider::Openai { base_url, api_key } => {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => {
                 let s =
                     provider::openai::chat_completion_stream(client, base_url, api_key, request)
                         .await?;
                 Ok(s.boxed())
             }
-            Provider::Anthropic { api_key } => {
+            RemoteProvider::Anthropic { client, api_key } => {
                 let s = provider::anthropic::chat_completion_stream(
                     client,
                     api_key,
@@ -255,7 +207,7 @@ impl Provider {
                 .await?;
                 Ok(s.boxed())
             }
-            Provider::Google { api_key } => {
+            RemoteProvider::Google { client, api_key } => {
                 let s = provider::google::chat_completion_stream(
                     client,
                     api_key,
@@ -266,7 +218,8 @@ impl Provider {
                 Ok(s.boxed())
             }
             #[cfg(feature = "provider-bedrock")]
-            Provider::Bedrock {
+            RemoteProvider::Bedrock {
+                client,
                 region,
                 access_key,
                 secret_key,
@@ -283,8 +236,9 @@ impl Provider {
                 Ok(s.boxed())
             }
             #[cfg(not(feature = "provider-bedrock"))]
-            Provider::Bedrock { .. } => Err(provider::bedrock::not_implemented("streaming")),
-            Provider::Azure {
+            RemoteProvider::Bedrock { .. } => Err(provider::bedrock::not_implemented("streaming")),
+            RemoteProvider::Azure {
+                client,
                 base_url,
                 api_key,
                 api_version,
@@ -298,6 +252,130 @@ impl Provider {
                 )
                 .await?;
                 Ok(s.boxed())
+            }
+        }
+    }
+
+    async fn embedding(
+        &self,
+        request: &EmbeddingRequest,
+    ) -> Result<EmbeddingResponse, Error> {
+        match self {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => provider::openai::embedding(client, base_url, api_key, request).await,
+            RemoteProvider::Anthropic { .. } => Err(provider::anthropic::not_implemented("embedding")),
+            RemoteProvider::Google { .. } => Err(provider::google::not_implemented("embedding")),
+            RemoteProvider::Bedrock { .. } => Err(provider::bedrock::not_implemented("embedding")),
+            RemoteProvider::Azure {
+                client,
+                base_url,
+                api_key,
+                api_version,
+            } => provider::azure::embedding(client, base_url, api_key, api_version, request).await,
+        }
+    }
+
+    async fn image_generation(
+        &self,
+        request: &ImageRequest,
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => provider::openai::image_generation(client, base_url, api_key, request).await,
+            RemoteProvider::Anthropic { .. } => {
+                Err(provider::anthropic::not_implemented("image_generation"))
+            }
+            RemoteProvider::Google { .. } => {
+                Err(provider::google::not_implemented("image_generation"))
+            }
+            RemoteProvider::Bedrock { .. } => {
+                Err(provider::bedrock::not_implemented("image_generation"))
+            }
+            RemoteProvider::Azure {
+                client,
+                base_url,
+                api_key,
+                api_version,
+            } => {
+                provider::azure::image_generation(client, base_url, api_key, api_version, request)
+                    .await
+            }
+        }
+    }
+
+    async fn audio_speech(
+        &self,
+        request: &AudioSpeechRequest,
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => provider::openai::audio_speech(client, base_url, api_key, request).await,
+            RemoteProvider::Anthropic { .. } => {
+                Err(provider::anthropic::not_implemented("audio_speech"))
+            }
+            RemoteProvider::Google { .. } => Err(provider::google::not_implemented("audio_speech")),
+            RemoteProvider::Bedrock { .. } => {
+                Err(provider::bedrock::not_implemented("audio_speech"))
+            }
+            RemoteProvider::Azure {
+                client,
+                base_url,
+                api_key,
+                api_version,
+            } => {
+                provider::azure::audio_speech(client, base_url, api_key, api_version, request).await
+            }
+        }
+    }
+
+    async fn audio_transcription(
+        &self,
+        model: &str,
+        fields: &[MultipartField],
+    ) -> Result<(Bytes, String), Error> {
+        match self {
+            RemoteProvider::Openai {
+                client,
+                base_url,
+                api_key,
+            } => {
+                let form = rebuild_form(fields);
+                provider::openai::audio_transcription(client, base_url, api_key, form).await
+            }
+            RemoteProvider::Anthropic { .. } => {
+                Err(provider::anthropic::not_implemented("audio_transcription"))
+            }
+            RemoteProvider::Google { .. } => {
+                Err(provider::google::not_implemented("audio_transcription"))
+            }
+            RemoteProvider::Bedrock { .. } => {
+                Err(provider::bedrock::not_implemented("audio_transcription"))
+            }
+            RemoteProvider::Azure {
+                client,
+                base_url,
+                api_key,
+                api_version,
+            } => {
+                let form = rebuild_form(fields);
+                provider::azure::audio_transcription(
+                    client,
+                    base_url,
+                    api_key,
+                    api_version,
+                    model,
+                    form,
+                )
+                .await
             }
         }
     }

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -321,10 +321,7 @@ impl<P: Provider> Provider for ProviderRegistry<P> {
         deployment.provider.chat_completion_stream(request).await
     }
 
-    async fn embedding(
-        &self,
-        request: &EmbeddingRequest,
-    ) -> Result<EmbeddingResponse, Error> {
+    async fn embedding(&self, request: &EmbeddingRequest) -> Result<EmbeddingResponse, Error> {
         let model = self.resolve(&request.model);
         let deployment = self
             .dispatch(model)
@@ -332,10 +329,7 @@ impl<P: Provider> Provider for ProviderRegistry<P> {
         deployment.provider.embedding(request).await
     }
 
-    async fn image_generation(
-        &self,
-        request: &ImageRequest,
-    ) -> Result<(Bytes, String), Error> {
+    async fn image_generation(&self, request: &ImageRequest) -> Result<(Bytes, String), Error> {
         let model = self.resolve(&request.model);
         let deployment = self
             .dispatch(model)
@@ -343,10 +337,7 @@ impl<P: Provider> Provider for ProviderRegistry<P> {
         deployment.provider.image_generation(request).await
     }
 
-    async fn audio_speech(
-        &self,
-        request: &AudioSpeechRequest,
-    ) -> Result<(Bytes, String), Error> {
+    async fn audio_speech(&self, request: &AudioSpeechRequest) -> Result<(Bytes, String), Error> {
         let model = self.resolve(&request.model);
         let deployment = self
             .dispatch(model)

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -148,16 +148,37 @@ impl<P> ProviderRegistry<P> {
 }
 
 impl<P> ProviderRegistry<P> {
-    /// Build the registry from gateway config, wrapping each constructed
-    /// `RemoteProvider` with `wrap` so the binary can lift it into a
-    /// workspace-level union type.
+    /// Build the registry from a full `GatewayConfig`. Thin wrapper around
+    /// [`from_provider_configs`](Self::from_provider_configs) that pulls the
+    /// two fields the registry actually cares about.
     pub fn from_config<F>(config: &GatewayConfig, wrap: F) -> Result<Self, Error>
+    where
+        F: Fn(RemoteProvider) -> P,
+    {
+        Self::from_provider_configs(&config.providers, &config.aliases, wrap)
+    }
+
+    /// Build the registry directly from a provider map and an alias map,
+    /// without requiring a full `GatewayConfig`. Intended for library
+    /// consumers that construct a handful of providers programmatically and
+    /// don't carry the rest of the gateway's runtime config
+    /// (listen address, storage, extensions, …).
+    ///
+    /// `wrap` lifts each constructed `RemoteProvider` into the workspace-
+    /// level concrete type the caller uses as `P` — e.g., a union enum
+    /// with one variant per provider source, or the identity closure when
+    /// `P = RemoteProvider`.
+    pub fn from_provider_configs<F>(
+        providers_config: &HashMap<String, ProviderConfig>,
+        aliases: &HashMap<String, String>,
+        wrap: F,
+    ) -> Result<Self, Error>
     where
         F: Fn(RemoteProvider) -> P,
     {
         // Validate against the raw config so we don't waste a `reqwest::Client`
         // construction (TLS init) on inputs we'd reject.
-        for (provider_name, provider_config) in &config.providers {
+        for (provider_name, provider_config) in providers_config {
             validate_provider(provider_name, provider_config)?;
         }
 
@@ -167,7 +188,7 @@ impl<P> ProviderRegistry<P> {
 
         let mut providers: HashMap<String, Vec<Arc<Deployment<P>>>> = HashMap::new();
 
-        for provider_config in config.providers.values() {
+        for provider_config in providers_config.values() {
             let provider = wrap(RemoteProvider::new(provider_config, client.clone()));
 
             let deployment = Arc::new(Deployment {
@@ -185,17 +206,13 @@ impl<P> ProviderRegistry<P> {
         }
 
         let mut model_providers = HashMap::new();
-        for (provider_name, provider_config) in &config.providers {
+        for (provider_name, provider_config) in providers_config {
             for model in &provider_config.models {
                 model_providers.insert(model.clone(), provider_name.clone());
             }
         }
 
-        Ok(Self::new(
-            providers,
-            config.aliases.clone(),
-            model_providers,
-        ))
+        Ok(Self::new(providers, aliases.clone(), model_providers))
     }
 }
 

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -243,33 +243,29 @@ fn validate_provider(name: &str, config: &ProviderConfig) -> Result<(), Error> {
             }
             Ok(())
         }
+        #[cfg(not(feature = "provider-bedrock"))]
+        ProviderKind::Bedrock => Err(Error::Config(format!(
+            "provider '{name}' uses kind = 'bedrock', which requires the \
+             'provider-bedrock' feature to be enabled in the crabllm binary"
+        ))),
+        #[cfg(feature = "provider-bedrock")]
         ProviderKind::Bedrock => {
-            #[cfg(not(feature = "provider-bedrock"))]
-            {
+            if is_blank(&config.region) {
                 return Err(Error::Config(format!(
-                    "provider '{name}' uses kind = 'bedrock', which requires the \
-                     'provider-bedrock' feature to be enabled in the crabllm binary"
+                    "provider '{name}' (bedrock) requires a region"
                 )));
             }
-            #[cfg(feature = "provider-bedrock")]
-            {
-                if is_blank(&config.region) {
-                    return Err(Error::Config(format!(
-                        "provider '{name}' (bedrock) requires a region"
-                    )));
-                }
-                if is_blank(&config.access_key) {
-                    return Err(Error::Config(format!(
-                        "provider '{name}' (bedrock) requires an access_key"
-                    )));
-                }
-                if is_blank(&config.secret_key) {
-                    return Err(Error::Config(format!(
-                        "provider '{name}' (bedrock) requires a secret_key"
-                    )));
-                }
-                Ok(())
+            if is_blank(&config.access_key) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (bedrock) requires an access_key"
+                )));
             }
+            if is_blank(&config.secret_key) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (bedrock) requires a secret_key"
+                )));
+            }
+            Ok(())
         }
         ProviderKind::LlamaCpp => {
             // When the `llamacpp` feature is enabled, `spawn_llamacpp_servers`

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -1,7 +1,7 @@
 use crate::{RemoteProvider, make_client};
 use crabllm_core::{Error, GatewayConfig, ProviderConfig, ProviderKind};
 use rand::Rng;
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 /// A provider entry with its routing weight and retry config.
 ///
@@ -9,7 +9,12 @@ use std::{collections::HashMap, time::Duration};
 /// implementing `crabllm_core::Provider` — typically a workspace-level
 /// union enum that delegates to multiple sources (built-in remote APIs,
 /// local backends, etc.).
-#[derive(Debug, Clone)]
+///
+/// Note: `Deployment` does not derive `Clone`. The registry stores
+/// `Arc<Deployment<P>>` internally so multiple model → deployment bindings
+/// share a single allocation, and so `P` is free to hold non-`Clone` state
+/// (e.g. model mmaps, CUDA contexts, task handles).
+#[derive(Debug)]
 pub struct Deployment<P> {
     pub provider: P,
     pub weight: u16,
@@ -18,18 +23,32 @@ pub struct Deployment<P> {
 }
 
 /// Maps model names to weighted provider lists for routing.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProviderRegistry<P> {
-    providers: HashMap<String, Vec<Deployment<P>>>,
+    providers: HashMap<String, Vec<Arc<Deployment<P>>>>,
     aliases: HashMap<String, String>,
     /// Precomputed model name → provider name lookup (avoids per-request HashMap rebuild).
     model_providers: HashMap<String, String>,
 }
 
+/// Manual `Clone` impl so the bound is not `P: Clone` — only the outer
+/// `HashMap`/`Vec`/`Arc` layers clone, and `Arc::clone` is infallible for
+/// any `T`. Cloning the registry is a shallow structural copy; every
+/// clone shares the same underlying `Deployment` allocations.
+impl<P> Clone for ProviderRegistry<P> {
+    fn clone(&self) -> Self {
+        Self {
+            providers: self.providers.clone(),
+            aliases: self.aliases.clone(),
+            model_providers: self.model_providers.clone(),
+        }
+    }
+}
+
 impl<P> ProviderRegistry<P> {
     /// Create a registry directly from pre-built provider lists and aliases.
     pub fn new(
-        providers: HashMap<String, Vec<Deployment<P>>>,
+        providers: HashMap<String, Vec<Arc<Deployment<P>>>>,
         aliases: HashMap<String, String>,
         model_providers: HashMap<String, String>,
     ) -> Self {
@@ -108,16 +127,16 @@ impl<P> ProviderRegistry<P> {
         };
 
         // Build result: selected first, then remaining sorted by descending weight.
-        let mut result = Vec::with_capacity(list.len());
+        let mut result: Vec<&Deployment<P>> = Vec::with_capacity(list.len());
         result.push(&list[selected_idx]);
 
-        let mut remaining: Vec<(usize, &Deployment<P>)> = list
+        let mut remaining: Vec<(usize, &Arc<Deployment<P>>)> = list
             .iter()
             .enumerate()
             .filter(|(i, _)| *i != selected_idx)
             .collect();
         remaining.sort_by(|a, b| b.1.weight.cmp(&a.1.weight));
-        result.extend(remaining.into_iter().map(|(_, d)| d));
+        result.extend(remaining.into_iter().map(|(_, d)| d.as_ref()));
 
         Some(result)
     }
@@ -128,10 +147,10 @@ impl<P> ProviderRegistry<P> {
     }
 }
 
-impl<P: Clone> ProviderRegistry<P> {
+impl<P> ProviderRegistry<P> {
     /// Build the registry from gateway config, wrapping each constructed
     /// `RemoteProvider` with `wrap` so the binary can lift it into a
-    /// workspace-level union type (e.g., a `Dispatch` enum).
+    /// workspace-level union type.
     pub fn from_config<F>(config: &GatewayConfig, wrap: F) -> Result<Self, Error>
     where
         F: Fn(RemoteProvider) -> P,
@@ -146,22 +165,22 @@ impl<P: Clone> ProviderRegistry<P> {
         // dispatches through the same connection pool.
         let client = make_client();
 
-        let mut providers: HashMap<String, Vec<Deployment<P>>> = HashMap::new();
+        let mut providers: HashMap<String, Vec<Arc<Deployment<P>>>> = HashMap::new();
 
         for provider_config in config.providers.values() {
             let provider = wrap(RemoteProvider::new(provider_config, client.clone()));
 
-            let deployment = Deployment {
+            let deployment = Arc::new(Deployment {
                 provider,
                 weight: provider_config.weight.unwrap_or(1),
                 max_retries: provider_config.max_retries.unwrap_or(2),
                 timeout: Duration::from_secs(provider_config.timeout.unwrap_or(30)),
-            };
+            });
             for model_name in &provider_config.models {
                 providers
                     .entry(model_name.clone())
                     .or_default()
-                    .push(deployment.clone());
+                    .push(Arc::clone(&deployment));
             }
         }
 

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -359,7 +359,10 @@ impl<P: Provider> Provider for ProviderRegistry<P> {
 }
 
 fn model_not_registered(model: &str) -> Error {
-    Error::Config(format!(
+    // Not `Error::Config`: this is a runtime routing miss, not a TOML parse
+    // problem. The taxonomy is missing a real `NotFound` variant — see the
+    // follow-up issue. `Internal` is the lesser evil among existing variants.
+    Error::Internal(format!(
         "model '{model}' not registered in provider registry"
     ))
 }

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -244,22 +244,32 @@ fn validate_provider(name: &str, config: &ProviderConfig) -> Result<(), Error> {
             Ok(())
         }
         ProviderKind::Bedrock => {
-            if is_blank(&config.region) {
+            #[cfg(not(feature = "provider-bedrock"))]
+            {
                 return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires a region"
+                    "provider '{name}' uses kind = 'bedrock', which requires the \
+                     'provider-bedrock' feature to be enabled in the crabllm binary"
                 )));
             }
-            if is_blank(&config.access_key) {
-                return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires an access_key"
-                )));
+            #[cfg(feature = "provider-bedrock")]
+            {
+                if is_blank(&config.region) {
+                    return Err(Error::Config(format!(
+                        "provider '{name}' (bedrock) requires a region"
+                    )));
+                }
+                if is_blank(&config.access_key) {
+                    return Err(Error::Config(format!(
+                        "provider '{name}' (bedrock) requires an access_key"
+                    )));
+                }
+                if is_blank(&config.secret_key) {
+                    return Err(Error::Config(format!(
+                        "provider '{name}' (bedrock) requires a secret_key"
+                    )));
+                }
+                Ok(())
             }
-            if is_blank(&config.secret_key) {
-                return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires a secret_key"
-                )));
-            }
-            Ok(())
         }
         ProviderKind::LlamaCpp => {
             // When the `llamacpp` feature is enabled, `spawn_llamacpp_servers`

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::RemoteProvider;
+use crate::{RemoteProvider, make_client};
 use crabllm_core::{Error, GatewayConfig, ProviderConfig, ProviderKind};
 use rand::Rng;
 use std::{collections::HashMap, time::Duration};
@@ -142,10 +142,14 @@ impl<P: Clone> ProviderRegistry<P> {
             validate_provider(provider_name, provider_config)?;
         }
 
+        // One shared `reqwest::Client` — cheap to clone, so every provider
+        // dispatches through the same connection pool.
+        let client = make_client();
+
         let mut providers: HashMap<String, Vec<Deployment<P>>> = HashMap::new();
 
         for provider_config in config.providers.values() {
-            let provider = wrap(RemoteProvider::from(provider_config));
+            let provider = wrap(RemoteProvider::new(provider_config, client.clone()));
 
             let deployment = Deployment {
                 provider,

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -1,12 +1,17 @@
-use crate::Provider;
-use crabllm_core::{Error, GatewayConfig};
+use crate::RemoteProvider;
+use crabllm_core::{Error, GatewayConfig, ProviderConfig, ProviderKind};
 use rand::Rng;
 use std::{collections::HashMap, time::Duration};
 
 /// A provider entry with its routing weight and retry config.
+///
+/// Generic over `P` so the binary can supply any concrete provider type
+/// implementing `crabllm_core::Provider` — typically a workspace-level
+/// union enum that delegates to multiple sources (built-in remote APIs,
+/// local backends, etc.).
 #[derive(Debug, Clone)]
-pub struct Deployment {
-    pub provider: Provider,
+pub struct Deployment<P> {
+    pub provider: P,
     pub weight: u16,
     pub max_retries: u32,
     pub timeout: Duration,
@@ -14,17 +19,17 @@ pub struct Deployment {
 
 /// Maps model names to weighted provider lists for routing.
 #[derive(Debug, Clone)]
-pub struct ProviderRegistry {
-    providers: HashMap<String, Vec<Deployment>>,
+pub struct ProviderRegistry<P> {
+    providers: HashMap<String, Vec<Deployment<P>>>,
     aliases: HashMap<String, String>,
     /// Precomputed model name → provider name lookup (avoids per-request HashMap rebuild).
     model_providers: HashMap<String, String>,
 }
 
-impl ProviderRegistry {
+impl<P> ProviderRegistry<P> {
     /// Create a registry directly from pre-built provider lists and aliases.
     pub fn new(
-        providers: HashMap<String, Vec<Deployment>>,
+        providers: HashMap<String, Vec<Deployment<P>>>,
         aliases: HashMap<String, String>,
         model_providers: HashMap<String, String>,
     ) -> Self {
@@ -35,17 +40,112 @@ impl ProviderRegistry {
         }
     }
 
-    /// Build the registry from gateway config.
-    pub fn from_config(config: &GatewayConfig) -> Result<Self, Error> {
-        for (provider_name, provider_config) in &config.providers {
-            let p = Provider::from(provider_config);
-            validate_provider(provider_name, provider_config, &p)?;
+    /// Look up the provider name for a model. O(1) HashMap lookup.
+    pub fn provider_name(&self, model: &str) -> Option<&str> {
+        self.model_providers.get(model).map(|s| s.as_str())
+    }
+
+    /// Return all registered model names.
+    pub fn model_names(&self) -> impl Iterator<Item = &str> {
+        self.model_providers.keys().map(|s| s.as_str())
+    }
+
+    /// Resolve a model name through aliases. Returns the canonical name.
+    pub fn resolve<'a>(&'a self, model: &'a str) -> &'a str {
+        self.aliases.get(model).map(|s| s.as_str()).unwrap_or(model)
+    }
+
+    /// Select a provider for a model using weighted random selection.
+    /// Returns None if the model is not registered.
+    pub fn dispatch(&self, model: &str) -> Option<&Deployment<P>> {
+        let list = self.providers.get(model)?;
+        if list.len() == 1 {
+            return Some(&list[0]);
         }
 
-        let mut providers: HashMap<String, Vec<Deployment>> = HashMap::new();
+        let total: u32 = list.iter().map(|d| d.weight as u32).sum();
+        if total == 0 {
+            return Some(&list[0]);
+        }
+
+        let mut pick = rand::rng().random_range(0..total);
+        for d in list {
+            let w = d.weight as u32;
+            if pick < w {
+                return Some(d);
+            }
+            pick -= w;
+        }
+
+        // Fallback (shouldn't happen).
+        Some(&list[0])
+    }
+
+    /// Return all deployments for a model, ordered for fallback:
+    /// selected provider first, then remaining sorted by descending weight.
+    /// Returns None if the model is not registered.
+    pub fn dispatch_list(&self, model: &str) -> Option<Vec<&Deployment<P>>> {
+        let list = self.providers.get(model)?;
+        if list.len() == 1 {
+            return Some(vec![&list[0]]);
+        }
+
+        let total: u32 = list.iter().map(|d| d.weight as u32).sum();
+        let selected_idx = if total == 0 {
+            0
+        } else {
+            let mut pick = rand::rng().random_range(0..total);
+            let mut idx = 0;
+            for (i, d) in list.iter().enumerate() {
+                let w = d.weight as u32;
+                if pick < w {
+                    idx = i;
+                    break;
+                }
+                pick -= w;
+            }
+            idx
+        };
+
+        // Build result: selected first, then remaining sorted by descending weight.
+        let mut result = Vec::with_capacity(list.len());
+        result.push(&list[selected_idx]);
+
+        let mut remaining: Vec<(usize, &Deployment<P>)> = list
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != selected_idx)
+            .collect();
+        remaining.sort_by(|a, b| b.1.weight.cmp(&a.1.weight));
+        result.extend(remaining.into_iter().map(|(_, d)| d));
+
+        Some(result)
+    }
+
+    /// Check if a model is registered (after alias resolution).
+    pub fn has_model(&self, model: &str) -> bool {
+        self.providers.contains_key(model)
+    }
+}
+
+impl<P: Clone> ProviderRegistry<P> {
+    /// Build the registry from gateway config, wrapping each constructed
+    /// `RemoteProvider` with `wrap` so the binary can lift it into a
+    /// workspace-level union type (e.g., a `Dispatch` enum).
+    pub fn from_config<F>(config: &GatewayConfig, wrap: F) -> Result<Self, Error>
+    where
+        F: Fn(RemoteProvider) -> P,
+    {
+        // Validate against the raw config so we don't waste a `reqwest::Client`
+        // construction (TLS init) on inputs we'd reject.
+        for (provider_name, provider_config) in &config.providers {
+            validate_provider(provider_name, provider_config)?;
+        }
+
+        let mut providers: HashMap<String, Vec<Deployment<P>>> = HashMap::new();
 
         for provider_config in config.providers.values() {
-            let provider = Provider::from(provider_config);
+            let provider = wrap(RemoteProvider::from(provider_config));
 
             let deployment = Deployment {
                 provider,
@@ -74,137 +174,63 @@ impl ProviderRegistry {
             model_providers,
         ))
     }
-
-    /// Look up the provider name for a model. O(1) HashMap lookup.
-    pub fn provider_name(&self, model: &str) -> Option<&str> {
-        self.model_providers.get(model).map(|s| s.as_str())
-    }
-
-    /// Return all registered model names.
-    pub fn model_names(&self) -> impl Iterator<Item = &str> {
-        self.model_providers.keys().map(|s| s.as_str())
-    }
-
-    /// Resolve a model name through aliases. Returns the canonical name.
-    pub fn resolve<'a>(&'a self, model: &'a str) -> &'a str {
-        self.aliases.get(model).map(|s| s.as_str()).unwrap_or(model)
-    }
-
-    /// Select a provider for a model using weighted random selection.
-    /// Returns None if the model is not registered.
-    pub fn dispatch(&self, model: &str) -> Option<&Deployment> {
-        let list = self.providers.get(model)?;
-        if list.len() == 1 {
-            return Some(&list[0]);
-        }
-
-        let total: u32 = list.iter().map(|d| d.weight as u32).sum();
-        if total == 0 {
-            return Some(&list[0]);
-        }
-
-        let mut pick = rand::rng().random_range(0..total);
-        for d in list {
-            let w = d.weight as u32;
-            if pick < w {
-                return Some(d);
-            }
-            pick -= w;
-        }
-
-        // Fallback (shouldn't happen).
-        Some(&list[0])
-    }
-
-    /// Return all deployments for a model, ordered for fallback:
-    /// selected provider first, then remaining sorted by descending weight.
-    /// Returns None if the model is not registered.
-    pub fn dispatch_list(&self, model: &str) -> Option<Vec<&Deployment>> {
-        let list = self.providers.get(model)?;
-        if list.len() == 1 {
-            return Some(vec![&list[0]]);
-        }
-
-        let total: u32 = list.iter().map(|d| d.weight as u32).sum();
-        let selected_idx = if total == 0 {
-            0
-        } else {
-            let mut pick = rand::rng().random_range(0..total);
-            let mut idx = 0;
-            for (i, d) in list.iter().enumerate() {
-                let w = d.weight as u32;
-                if pick < w {
-                    idx = i;
-                    break;
-                }
-                pick -= w;
-            }
-            idx
-        };
-
-        // Build result: selected first, then remaining sorted by descending weight.
-        let mut result = Vec::with_capacity(list.len());
-        result.push(&list[selected_idx]);
-
-        let mut remaining: Vec<(usize, &Deployment)> = list
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| *i != selected_idx)
-            .collect();
-        remaining.sort_by(|a, b| b.1.weight.cmp(&a.1.weight));
-        result.extend(remaining.into_iter().map(|(_, d)| d));
-
-        Some(result)
-    }
-
-    /// Check if a model is registered (after alias resolution).
-    pub fn has_model(&self, model: &str) -> bool {
-        self.providers.contains_key(model)
-    }
 }
 
-/// Validate provider-specific required fields.
-fn validate_provider(
-    name: &str,
-    config: &crabllm_core::ProviderConfig,
-    provider: &Provider,
-) -> Result<(), Error> {
-    match provider {
-        Provider::Openai { base_url, .. } if base_url.is_empty() => Err(Error::Config(format!(
-            "provider '{name}' ({:?}) requires a base_url",
-            config.kind,
-        ))),
-        Provider::Anthropic { api_key } | Provider::Google { api_key } if api_key.is_empty() => {
-            Err(Error::Config(format!(
-                "provider '{name}' ({:?}) requires an api_key",
-                config.kind,
-            )))
+/// Validate provider-specific required fields against the raw config.
+fn validate_provider(name: &str, config: &ProviderConfig) -> Result<(), Error> {
+    fn is_blank(opt: &Option<String>) -> bool {
+        opt.as_ref().is_none_or(|s| s.is_empty())
+    }
+    match config.kind {
+        ProviderKind::Openai | ProviderKind::Ollama => {
+            // Both have a sensible default base_url; nothing to require.
+            Ok(())
         }
-        Provider::Azure { api_key, .. } if api_key.is_empty() => Err(Error::Config(format!(
-            "provider '{name}' (azure) requires an api_key",
-        ))),
-        Provider::Bedrock {
-            region,
-            access_key,
-            secret_key,
-        } => {
-            if region.is_empty() {
+        ProviderKind::Anthropic | ProviderKind::Google => {
+            if is_blank(&config.api_key) {
                 return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires a region",
-                )));
-            }
-            if access_key.is_empty() {
-                return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires an access_key",
-                )));
-            }
-            if secret_key.is_empty() {
-                return Err(Error::Config(format!(
-                    "provider '{name}' (bedrock) requires a secret_key",
+                    "provider '{name}' ({:?}) requires an api_key",
+                    config.kind,
                 )));
             }
             Ok(())
         }
-        _ => Ok(()),
+        ProviderKind::Azure => {
+            if is_blank(&config.api_key) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (azure) requires an api_key"
+                )));
+            }
+            Ok(())
+        }
+        ProviderKind::Bedrock => {
+            if is_blank(&config.region) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (bedrock) requires a region"
+                )));
+            }
+            if is_blank(&config.access_key) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (bedrock) requires an access_key"
+                )));
+            }
+            if is_blank(&config.secret_key) {
+                return Err(Error::Config(format!(
+                    "provider '{name}' (bedrock) requires a secret_key"
+                )));
+            }
+            Ok(())
+        }
+        ProviderKind::LlamaCpp => {
+            // When the `llamacpp` feature is enabled, `spawn_llamacpp_servers`
+            // rewrites the config kind to `Openai` before this runs — so
+            // seeing `LlamaCpp` here means the feature is off (or the spawn
+            // step didn't run). Reject explicitly rather than constructing a
+            // broken `Openai` stub with an empty base_url.
+            Err(Error::Config(format!(
+                "provider '{name}' uses kind = 'llamacpp', which requires the \
+                 'llamacpp' feature to be enabled in the crabllm binary"
+            )))
+        }
     }
 }

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -1,5 +1,10 @@
 use crate::{RemoteProvider, make_client};
-use crabllm_core::{Error, GatewayConfig, ProviderConfig, ProviderKind};
+use bytes::Bytes;
+use crabllm_core::{
+    AudioSpeechRequest, BoxStream, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse, Error, GatewayConfig,
+    ImageRequest, MultipartField, Provider, ProviderConfig, ProviderKind,
+};
 use rand::Rng;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -279,4 +284,91 @@ fn validate_provider(name: &str, config: &ProviderConfig) -> Result<(), Error> {
             )))
         }
     }
+}
+
+/// `ProviderRegistry<P>` is itself a `Provider`. Each call routes on the
+/// request's (alias-resolved) model name, picks one weighted deployment via
+/// `dispatch`, and forwards to the inner provider.
+///
+/// This lets downstream library consumers use the registry directly as a
+/// `P: Provider` — the registry handles model-name routing so the caller
+/// never has to touch `Deployment` or write their own delegation wrapper.
+///
+/// Note: this impl picks a single deployment and does not walk fallback
+/// deployments or retry. The HTTP proxy still drives its own retry/fallback
+/// loops over `&Deployment<P>` from `dispatch_list`, and does not dispatch
+/// through this impl.
+impl<P: Provider> Provider for ProviderRegistry<P> {
+    async fn chat_completion(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, Error> {
+        let model = self.resolve(&request.model);
+        let deployment = self
+            .dispatch(model)
+            .ok_or_else(|| model_not_registered(model))?;
+        deployment.provider.chat_completion(request).await
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error> {
+        let model = self.resolve(&request.model);
+        let deployment = self
+            .dispatch(model)
+            .ok_or_else(|| model_not_registered(model))?;
+        deployment.provider.chat_completion_stream(request).await
+    }
+
+    async fn embedding(
+        &self,
+        request: &EmbeddingRequest,
+    ) -> Result<EmbeddingResponse, Error> {
+        let model = self.resolve(&request.model);
+        let deployment = self
+            .dispatch(model)
+            .ok_or_else(|| model_not_registered(model))?;
+        deployment.provider.embedding(request).await
+    }
+
+    async fn image_generation(
+        &self,
+        request: &ImageRequest,
+    ) -> Result<(Bytes, String), Error> {
+        let model = self.resolve(&request.model);
+        let deployment = self
+            .dispatch(model)
+            .ok_or_else(|| model_not_registered(model))?;
+        deployment.provider.image_generation(request).await
+    }
+
+    async fn audio_speech(
+        &self,
+        request: &AudioSpeechRequest,
+    ) -> Result<(Bytes, String), Error> {
+        let model = self.resolve(&request.model);
+        let deployment = self
+            .dispatch(model)
+            .ok_or_else(|| model_not_registered(model))?;
+        deployment.provider.audio_speech(request).await
+    }
+
+    async fn audio_transcription(
+        &self,
+        model: &str,
+        fields: &[MultipartField],
+    ) -> Result<(Bytes, String), Error> {
+        let resolved = self.resolve(model);
+        let deployment = self
+            .dispatch(resolved)
+            .ok_or_else(|| model_not_registered(resolved))?;
+        deployment.provider.audio_transcription(model, fields).await
+    }
+}
+
+fn model_not_registered(model: &str) -> Error {
+    Error::Config(format!(
+        "model '{model}' not registered in provider registry"
+    ))
 }

--- a/crates/proxy/src/auth.rs
+++ b/crates/proxy/src/auth.rs
@@ -15,7 +15,7 @@ pub struct KeyName(pub Option<String>);
 /// Auth middleware: validates Bearer token against configured virtual keys.
 /// Skips auth only when no admin_token is configured AND key_map is empty.
 /// Inserts `KeyName` into request extensions for downstream handlers.
-pub async fn auth<S: Storage + 'static, P: Provider + Clone + 'static>(
+pub async fn auth<S: Storage + 'static, P: Provider + 'static>(
     State(state): State<AppState<S, P>>,
     mut request: Request,
     next: Next,

--- a/crates/proxy/src/auth.rs
+++ b/crates/proxy/src/auth.rs
@@ -6,7 +6,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use crabllm_core::{ApiError, Storage};
+use crabllm_core::{ApiError, Provider, Storage};
 
 /// Wrapper for the authenticated key name, inserted into request extensions.
 #[derive(Clone, Debug)]
@@ -15,8 +15,8 @@ pub struct KeyName(pub Option<String>);
 /// Auth middleware: validates Bearer token against configured virtual keys.
 /// Skips auth only when no admin_token is configured AND key_map is empty.
 /// Inserts `KeyName` into request extensions for downstream handlers.
-pub async fn auth<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn auth<S: Storage + 'static, P: Provider + Clone + 'static>(
+    State(state): State<AppState<S, P>>,
     mut request: Request,
     next: Next,
 ) -> Response {

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -70,7 +70,7 @@ pub async fn chat_completions<S, P>(
 ) -> Response
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
@@ -252,7 +252,7 @@ pub async fn embeddings<S, P>(
 ) -> Response
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
@@ -319,7 +319,7 @@ where
 pub async fn models<S, P>(State(state): State<AppState<S, P>>) -> Json<ModelList>
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let data: Vec<Model> = state
         .registry
@@ -346,7 +346,7 @@ pub async fn image_generations<S, P>(
 ) -> Response
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
@@ -422,7 +422,7 @@ pub async fn audio_speech<S, P>(
 ) -> Response
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
@@ -498,7 +498,7 @@ pub async fn audio_transcriptions<S, P>(
 ) -> Response
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     // Buffer all multipart fields and extract the model name.
     let mut fields = Vec::with_capacity(8);

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use crabllm_core::{
     ApiError, AudioSpeechRequest, ChatCompletionRequest, EmbeddingRequest, ImageRequest, Model,
-    ModelList, RequestContext, Storage,
+    ModelList, MultipartField, RequestContext, Storage,
 };
 use crabllm_provider::Deployment;
 use futures::StreamExt;
@@ -471,16 +471,8 @@ pub async fn audio_speech<S: Storage + 'static>(
     error_response(e)
 }
 
-/// A buffered multipart field for reconstructing forms across fallback attempts.
-struct BufferedField {
-    name: String,
-    filename: Option<String>,
-    content_type: Option<String>,
-    bytes: bytes::Bytes,
-}
-
 /// Rebuild a `reqwest::multipart::Form` from buffered fields.
-fn rebuild_form(fields: &[BufferedField]) -> reqwest::multipart::Form {
+fn rebuild_form(fields: &[MultipartField]) -> reqwest::multipart::Form {
     let mut form = reqwest::multipart::Form::new();
     for field in fields {
         let mut part = reqwest::multipart::Part::stream(field.bytes.clone());
@@ -531,7 +523,7 @@ pub async fn audio_transcriptions<S: Storage + 'static>(
         if name == "model" {
             model_value = Some(String::from_utf8_lossy(&bytes).into_owned());
         }
-        fields.push(BufferedField {
+        fields.push(MultipartField {
             name,
             filename,
             content_type,

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -732,12 +732,7 @@ async fn try_embedding_with_retries<P: Provider>(
     request: &EmbeddingRequest,
 ) -> Result<crabllm_core::EmbeddingResponse, crabllm_core::Error> {
     let mut last_err;
-    match with_timeout(
-        deployment.timeout,
-        deployment.provider.embedding(request),
-    )
-    .await
-    {
+    match with_timeout(deployment.timeout, deployment.provider.embedding(request)).await {
         Ok(resp) => return Ok(resp),
         Err(e) => {
             if !e.is_transient() || deployment.max_retries == 0 {
@@ -751,12 +746,7 @@ async fn try_embedding_with_retries<P: Provider>(
     for _ in 0..deployment.max_retries {
         tokio::time::sleep(jittered(backoff)).await;
         backoff *= 2;
-        match with_timeout(
-            deployment.timeout,
-            deployment.provider.embedding(request),
-        )
-        .await
-        {
+        match with_timeout(deployment.timeout, deployment.provider.embedding(request)).await {
             Ok(resp) => return Ok(resp),
             Err(e) => {
                 if !e.is_transient() {

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -9,8 +9,9 @@ use axum::{
     },
 };
 use crabllm_core::{
-    ApiError, AudioSpeechRequest, ChatCompletionRequest, EmbeddingRequest, ImageRequest, Model,
-    ModelList, MultipartField, RequestContext, Storage,
+    ApiError, AudioSpeechRequest, BoxStream, ChatCompletionChunk, ChatCompletionRequest,
+    EmbeddingRequest, ImageRequest, Model, ModelList, MultipartField, Provider, RequestContext,
+    Storage,
 };
 use crabllm_provider::Deployment;
 use futures::StreamExt;
@@ -62,11 +63,15 @@ fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
 }
 
 /// POST /v1/chat/completions
-pub async fn chat_completions<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn chat_completions<S, P>(
+    State(state): State<AppState<S, P>>,
     Extension(key_name): Extension<KeyName>,
     Json(mut request): Json<ChatCompletionRequest>,
-) -> Response {
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
         Some(list) => list,
@@ -120,7 +125,7 @@ pub async fn chat_completions<S: Storage + 'static>(
         // Streaming: retry + fallback on connection errors only (pre-stream).
         let mut last_err = None;
         for deployment in &deployments {
-            match try_stream_with_retries(deployment, &state.client, &request).await {
+            match try_stream_with_retries(deployment, &request).await {
                 Ok(stream) => {
                     let extensions = state.extensions.clone();
                     let ctx = Arc::new(ctx);
@@ -214,7 +219,7 @@ pub async fn chat_completions<S: Storage + 'static>(
 
         let mut last_err = None;
         for deployment in &deployments {
-            match try_chat_with_retries(deployment, &state.client, &request).await {
+            match try_chat_with_retries(deployment, &request).await {
                 Ok(resp) => {
                     if let Some(ref usage) = resp.usage {
                         record_tokens(&ctx, usage.prompt_tokens, usage.completion_tokens);
@@ -240,11 +245,15 @@ pub async fn chat_completions<S: Storage + 'static>(
 }
 
 /// POST /v1/embeddings
-pub async fn embeddings<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn embeddings<S, P>(
+    State(state): State<AppState<S, P>>,
     Extension(key_name): Extension<KeyName>,
     Json(request): Json<EmbeddingRequest>,
-) -> Response {
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
         Some(list) => list,
@@ -288,7 +297,7 @@ pub async fn embeddings<S: Storage + 'static>(
 
     let mut last_err = None;
     for deployment in &deployments {
-        match try_embedding_with_retries(deployment, &state.client, &request).await {
+        match try_embedding_with_retries(deployment, &request).await {
             Ok(resp) => {
                 record_duration(&ctx, "2xx");
                 return Json(resp).into_response();
@@ -307,7 +316,11 @@ pub async fn embeddings<S: Storage + 'static>(
 }
 
 /// GET /v1/models
-pub async fn models<S: Storage + 'static>(State(state): State<AppState<S>>) -> Json<ModelList> {
+pub async fn models<S, P>(State(state): State<AppState<S, P>>) -> Json<ModelList>
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     let data: Vec<Model> = state
         .registry
         .model_names()
@@ -326,11 +339,15 @@ pub async fn models<S: Storage + 'static>(State(state): State<AppState<S>>) -> J
 }
 
 /// POST /v1/images/generations
-pub async fn image_generations<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn image_generations<S, P>(
+    State(state): State<AppState<S, P>>,
     Extension(key_name): Extension<KeyName>,
     Json(request): Json<ImageRequest>,
-) -> Response {
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
         Some(list) => list,
@@ -376,9 +393,7 @@ pub async fn image_generations<S: Storage + 'static>(
     for deployment in &deployments {
         match with_timeout(
             deployment.timeout,
-            deployment
-                .provider
-                .image_generation(&state.client, &request),
+            deployment.provider.image_generation(&request),
         )
         .await
         {
@@ -400,11 +415,15 @@ pub async fn image_generations<S: Storage + 'static>(
 }
 
 /// POST /v1/audio/speech
-pub async fn audio_speech<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn audio_speech<S, P>(
+    State(state): State<AppState<S, P>>,
     Extension(key_name): Extension<KeyName>,
     Json(request): Json<AudioSpeechRequest>,
-) -> Response {
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     let model = state.registry.resolve(&request.model).to_string();
     let deployments = match state.registry.dispatch_list(&model) {
         Some(list) => list,
@@ -450,7 +469,7 @@ pub async fn audio_speech<S: Storage + 'static>(
     for deployment in &deployments {
         match with_timeout(
             deployment.timeout,
-            deployment.provider.audio_speech(&state.client, &request),
+            deployment.provider.audio_speech(&request),
         )
         .await
         {
@@ -471,30 +490,16 @@ pub async fn audio_speech<S: Storage + 'static>(
     error_response(e)
 }
 
-/// Rebuild a `reqwest::multipart::Form` from buffered fields.
-fn rebuild_form(fields: &[MultipartField]) -> reqwest::multipart::Form {
-    let mut form = reqwest::multipart::Form::new();
-    for field in fields {
-        let mut part = reqwest::multipart::Part::stream(field.bytes.clone());
-        if let Some(ref filename) = field.filename {
-            part = part.file_name(filename.clone());
-        }
-        if let Some(ref content_type) = field.content_type {
-            part = part
-                .mime_str(content_type)
-                .unwrap_or_else(|_| reqwest::multipart::Part::stream(field.bytes.clone()));
-        }
-        form = form.part(field.name.clone(), part);
-    }
-    form
-}
-
 /// POST /v1/audio/transcriptions
-pub async fn audio_transcriptions<S: Storage + 'static>(
-    State(state): State<AppState<S>>,
+pub async fn audio_transcriptions<S, P>(
+    State(state): State<AppState<S, P>>,
     Extension(key_name): Extension<KeyName>,
     mut multipart: Multipart,
-) -> Response {
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
     // Buffer all multipart fields and extract the model name.
     let mut fields = Vec::with_capacity(8);
     let mut model_value = None;
@@ -584,15 +589,13 @@ pub async fn audio_transcriptions<S: Storage + 'static>(
         }
     }
 
-    // Fallback only — rebuild form for each attempt.
+    // Fallback only (no retry loop) — provider impls rebuild a fresh
+    // multipart form per call from the buffered field slice.
     let mut last_err = None;
     for deployment in &deployments {
-        let form = rebuild_form(&fields);
         match with_timeout(
             deployment.timeout,
-            deployment
-                .provider
-                .audio_transcription(&state.client, &model, form),
+            deployment.provider.audio_transcription(&model, &fields),
         )
         .await
         {
@@ -635,15 +638,14 @@ fn jittered(backoff: Duration) -> Duration {
 }
 
 /// Retry a non-streaming chat completion on a single deployment.
-async fn try_chat_with_retries(
-    deployment: &Deployment,
-    client: &reqwest::Client,
+async fn try_chat_with_retries<P: Provider>(
+    deployment: &Deployment<P>,
     request: &ChatCompletionRequest,
 ) -> Result<crabllm_core::ChatCompletionResponse, crabllm_core::Error> {
     let mut last_err;
     match with_timeout(
         deployment.timeout,
-        deployment.provider.chat_completion(client, request),
+        deployment.provider.chat_completion(request),
     )
     .await
     {
@@ -662,7 +664,7 @@ async fn try_chat_with_retries(
         backoff *= 2;
         match with_timeout(
             deployment.timeout,
-            deployment.provider.chat_completion(client, request),
+            deployment.provider.chat_completion(request),
         )
         .await
         {
@@ -680,21 +682,15 @@ async fn try_chat_with_retries(
 }
 
 /// Retry a streaming chat completion on a single deployment.
-async fn try_stream_with_retries(
-    deployment: &Deployment,
-    client: &reqwest::Client,
+async fn try_stream_with_retries<P: Provider>(
+    deployment: &Deployment<P>,
     request: &ChatCompletionRequest,
-) -> Result<
-    futures::stream::BoxStream<
-        'static,
-        Result<crabllm_core::ChatCompletionChunk, crabllm_core::Error>,
-    >,
-    crabllm_core::Error,
-> {
+) -> Result<BoxStream<'static, Result<ChatCompletionChunk, crabllm_core::Error>>, crabllm_core::Error>
+{
     let mut last_err;
     match with_timeout(
         deployment.timeout,
-        deployment.provider.chat_completion_stream(client, request),
+        deployment.provider.chat_completion_stream(request),
     )
     .await
     {
@@ -713,7 +709,7 @@ async fn try_stream_with_retries(
         backoff *= 2;
         match with_timeout(
             deployment.timeout,
-            deployment.provider.chat_completion_stream(client, request),
+            deployment.provider.chat_completion_stream(request),
         )
         .await
         {
@@ -731,15 +727,14 @@ async fn try_stream_with_retries(
 }
 
 /// Retry an embedding request on a single deployment.
-async fn try_embedding_with_retries(
-    deployment: &Deployment,
-    client: &reqwest::Client,
+async fn try_embedding_with_retries<P: Provider>(
+    deployment: &Deployment<P>,
     request: &EmbeddingRequest,
 ) -> Result<crabllm_core::EmbeddingResponse, crabllm_core::Error> {
     let mut last_err;
     match with_timeout(
         deployment.timeout,
-        deployment.provider.embedding(client, request),
+        deployment.provider.embedding(request),
     )
     .await
     {
@@ -758,7 +753,7 @@ async fn try_embedding_with_retries(
         backoff *= 2;
         match with_timeout(
             deployment.timeout,
-            deployment.provider.embedding(client, request),
+            deployment.provider.embedding(request),
         )
         .await
         {

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -31,7 +31,7 @@ async fn track_active_connections(request: Request, next: middleware::Next) -> R
 pub fn router<S, P>(state: AppState<S, P>, admin_routes: Vec<Router>) -> Router
 where
     S: Storage + 'static,
-    P: Provider + Clone + 'static,
+    P: Provider + 'static,
 {
     let mut app = Router::<AppState<S, P>>::new()
         .route(

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -5,7 +5,7 @@ use axum::{
     response::Response,
     routing::{get, post},
 };
-use crabllm_core::Storage;
+use crabllm_core::{Provider, Storage};
 
 pub use auth::KeyName;
 pub use state::AppState;
@@ -28,26 +28,30 @@ async fn track_active_connections(request: Request, next: middleware::Next) -> R
 }
 
 /// Build the Axum router with all API routes and admin routes.
-pub fn router<S: Storage + 'static>(state: AppState<S>, admin_routes: Vec<Router>) -> Router {
-    let mut app = Router::<AppState<S>>::new()
+pub fn router<S, P>(state: AppState<S, P>, admin_routes: Vec<Router>) -> Router
+where
+    S: Storage + 'static,
+    P: Provider + Clone + 'static,
+{
+    let mut app = Router::<AppState<S, P>>::new()
         .route(
             "/v1/chat/completions",
-            post(handlers::chat_completions::<S>),
+            post(handlers::chat_completions::<S, P>),
         )
-        .route("/v1/embeddings", post(handlers::embeddings::<S>))
+        .route("/v1/embeddings", post(handlers::embeddings::<S, P>))
         .route(
             "/v1/images/generations",
-            post(handlers::image_generations::<S>),
+            post(handlers::image_generations::<S, P>),
         )
-        .route("/v1/audio/speech", post(handlers::audio_speech::<S>))
+        .route("/v1/audio/speech", post(handlers::audio_speech::<S, P>))
         .route(
             "/v1/audio/transcriptions",
-            post(handlers::audio_transcriptions::<S>),
+            post(handlers::audio_transcriptions::<S, P>),
         )
-        .route("/v1/models", get(handlers::models::<S>))
+        .route("/v1/models", get(handlers::models::<S, P>))
         .layer(middleware::from_fn_with_state(
             state.clone(),
-            auth::auth::<S>,
+            auth::auth::<S, P>,
         ))
         .layer(middleware::from_fn(track_active_connections))
         .with_state(state);

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -11,7 +11,7 @@ use std::{
 /// binary picks `P` by defining a workspace-level union enum that wraps
 /// every provider source it links — that enum implements `Provider` via
 /// match-and-delegate, so dispatch through `P` is fully monomorphized.
-pub struct AppState<S: Storage, P: Provider + Clone> {
+pub struct AppState<S: Storage, P: Provider> {
     pub registry: ProviderRegistry<P>,
     pub config: GatewayConfig,
     pub extensions: Arc<Vec<Box<dyn Extension>>>,
@@ -21,7 +21,7 @@ pub struct AppState<S: Storage, P: Provider + Clone> {
     pub key_map: Arc<RwLock<HashMap<String, String>>>,
 }
 
-impl<S: Storage, P: Provider + Clone> Clone for AppState<S, P> {
+impl<S: Storage, P: Provider> Clone for AppState<S, P> {
     fn clone(&self) -> Self {
         Self {
             registry: self.registry.clone(),

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -1,4 +1,4 @@
-use crabllm_core::{Extension, GatewayConfig, Storage};
+use crabllm_core::{Extension, GatewayConfig, Provider, Storage};
 use crabllm_provider::ProviderRegistry;
 use std::{
     collections::HashMap,
@@ -6,9 +6,13 @@ use std::{
 };
 
 /// Shared application state passed to all handlers.
-pub struct AppState<S: Storage> {
-    pub registry: ProviderRegistry,
-    pub client: reqwest::Client,
+///
+/// Generic over the storage backend `S` and the provider type `P`. The
+/// binary picks `P` by defining a workspace-level union enum that wraps
+/// every provider source it links — that enum implements `Provider` via
+/// match-and-delegate, so dispatch through `P` is fully monomorphized.
+pub struct AppState<S: Storage, P: Provider + Clone> {
+    pub registry: ProviderRegistry<P>,
     pub config: GatewayConfig,
     pub extensions: Arc<Vec<Box<dyn Extension>>>,
     pub storage: Arc<S>,
@@ -17,11 +21,10 @@ pub struct AppState<S: Storage> {
     pub key_map: Arc<RwLock<HashMap<String, String>>>,
 }
 
-impl<S: Storage> Clone for AppState<S> {
+impl<S: Storage, P: Provider + Clone> Clone for AppState<S, P> {
     fn clone(&self) -> Self {
         Self {
             registry: self.registry.clone(),
-            client: self.client.clone(),
             config: self.config.clone(),
             extensions: self.extensions.clone(),
             storage: self.storage.clone(),


### PR DESCRIPTION
Closes #42.

## Summary

- Introduces `crabllm_core::Provider` trait using RPITIT (`fn x() -> impl Future + Send`) — zero `dyn`, zero `Box<dyn>`, zero `BoxFuture` for trait dispatch. The proxy is generic over `P: Provider`; the binary defines a workspace-level `Dispatch` enum as the concrete type, monomorphized end-to-end.
- Renames the closed `Provider` enum in `crabllm-provider` to `RemoteProvider` and implements the trait for it. The 5 built-in provider files (`openai.rs`, `anthropic.rs`, `google.rs`, `bedrock.rs`, `azure.rs`) are not touched internally — only the wrapping enum is replaced.
- New providers (in-process backends, alternative APIs, etc.) join by adding a variant to `Dispatch` in `crates/crabllm/src/bin/main.rs` instead of editing `crabllm-provider`. The provider crate stops being the chokepoint for workspace composition.

## Architecture

```
core (trait Provider, MultipartField, BoxStream)
   ↑
   ├── provider (RemoteProvider + 5 built-ins, impl Provider)
   │       ↑
   └── proxy (generic over P) ── crabllm bin (Dispatch enum, P = Dispatch)
```

Non-goals: no runtime plugin loading, no stable third-party trait API, no integration of any specific new provider.

## Test plan

- [x] Workspace builds clean: `cargo build --workspace`
- [x] Workspace clippy clean: `cargo clippy --workspace`
- [x] Zero `dyn Provider` / `Arc<dyn Provider>` / `BoxFuture` for trait dispatch anywhere in the workspace
- [x] The 5 provider files in `crates/provider/src/provider/` are byte-identical to `main` (verified with `git diff main -- crates/provider/src/provider/`)
- [ ] Manual end-to-end smoke against a real OpenAI key: non-streaming chat, streaming chat, embeddings
- [ ] Manual end-to-end smoke against a real Anthropic key: non-streaming chat, streaming chat
- [ ] Manual smoke against a local llama-server (if `llamacpp` feature enabled): chat completion
- [ ] Confirm a `crabllm.toml` with `kind = "llama_cpp"` and the `llamacpp` feature off now errors at startup with the new `validate_provider` message instead of silently producing a broken provider
- [ ] Run the existing bench suite to confirm no perf regression vs `main`