### PR TITLE
feat(core): convenience helpers for library consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "High-performance LLM API gateway"
@@ -12,12 +12,12 @@ keywords = ["llm", "gateway", "proxy", "openai", "anthropic"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [workspace.dependencies]
-crabllm-core = { version = "0.0.14", path = "crates/core" }
-crabllm-provider = { version = "0.0.14", path = "crates/provider" }
-crabllm-proxy = { version = "0.0.14", path = "crates/proxy" }
-crabllm-bench = { version = "0.0.14", path = "crates/bench" }
-crabllm = { version = "0.0.14", path = "crates/crabllm" }
-crabllm-llamacpp = { version = "0.0.14", path = "crates/crabllm-llamacpp" }
+crabllm-core = { version = "0.0.15", path = "crates/core" }
+crabllm-provider = { version = "0.0.15", path = "crates/provider" }
+crabllm-proxy = { version = "0.0.15", path = "crates/proxy" }
+crabllm-bench = { version = "0.0.15", path = "crates/bench" }
+crabllm = { version = "0.0.15", path = "crates/crabllm" }
+crabllm-llamacpp = { version = "0.0.15", path = "crates/crabllm-llamacpp" }
 
 # crates-io
 axum = { version = "0.8", features = ["multipart"] }

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -328,6 +328,11 @@ pub struct Choice {
 }
 
 impl ChatCompletionResponse {
+    /// First choice's message, if present.
+    pub fn message(&self) -> Option<&Message> {
+        self.choices.first().map(|c| &c.message)
+    }
+
     /// Text content from the first choice's message, if non-empty.
     ///
     /// Empty strings collapse to `None` (via `Message::content_str`).

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -256,11 +256,15 @@ impl Message {
         msg
     }
 
-    /// Return the text view of `content` when it is a JSON string.
+    /// Return the text view of `content` when it is a non-empty JSON string.
     ///
-    /// Returns `None` for `null` and non-string variants (e.g. multimodal arrays).
+    /// Returns `None` for `null`, empty strings, and non-string variants
+    /// (e.g. multimodal arrays).
     pub fn content_str(&self) -> Option<&str> {
-        self.content.as_ref().and_then(serde_json::Value::as_str)
+        self.content
+            .as_ref()
+            .and_then(serde_json::Value::as_str)
+            .filter(|s| !s.is_empty())
     }
 }
 
@@ -324,14 +328,23 @@ pub struct Choice {
 }
 
 impl ChatCompletionResponse {
-    /// Text content from the first choice's message, if present.
+    /// Text content from the first choice's message, if non-empty.
+    ///
+    /// Empty strings collapse to `None` (via `Message::content_str`).
     pub fn content(&self) -> Option<&str> {
         self.choices.first()?.message.content_str()
     }
 
-    /// Reasoning content from the first choice's message, if present.
+    /// Reasoning content from the first choice's message, if non-empty.
+    ///
+    /// Empty strings collapse to `None`.
     pub fn reasoning_content(&self) -> Option<&str> {
-        self.choices.first()?.message.reasoning_content.as_deref()
+        self.choices
+            .first()?
+            .message
+            .reasoning_content
+            .as_deref()
+            .filter(|s| !s.is_empty())
     }
 
     /// Tool calls from the first choice's message. Empty slice if none.
@@ -383,14 +396,28 @@ pub struct ChatCompletionChunk {
 }
 
 impl ChatCompletionChunk {
-    /// Text delta from the first choice, if present.
+    /// Text delta from the first choice, if non-empty.
+    ///
+    /// Empty-string deltas (keepalives, boundary markers) collapse to `None`.
     pub fn content(&self) -> Option<&str> {
-        self.choices.first()?.delta.content.as_deref()
+        self.choices
+            .first()?
+            .delta
+            .content
+            .as_deref()
+            .filter(|s| !s.is_empty())
     }
 
-    /// Reasoning-content delta from the first choice, if present.
+    /// Reasoning-content delta from the first choice, if non-empty.
+    ///
+    /// Empty-string deltas collapse to `None`.
     pub fn reasoning_content(&self) -> Option<&str> {
-        self.choices.first()?.delta.reasoning_content.as_deref()
+        self.choices
+            .first()?
+            .delta
+            .reasoning_content
+            .as_deref()
+            .filter(|s| !s.is_empty())
     }
 
     /// Tool-call deltas from the first choice. Empty slice if none.

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -255,6 +255,13 @@ impl Message {
         msg.name = Some(name.into());
         msg
     }
+
+    /// Return the text view of `content` when it is a JSON string.
+    ///
+    /// Returns `None` for `null` and non-string variants (e.g. multimodal arrays).
+    pub fn content_str(&self) -> Option<&str> {
+        self.content.as_ref().and_then(serde_json::Value::as_str)
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -323,6 +323,31 @@ pub struct Choice {
     pub logprobs: Option<serde_json::Value>,
 }
 
+impl ChatCompletionResponse {
+    /// Text content from the first choice's message, if present.
+    pub fn content(&self) -> Option<&str> {
+        self.choices.first()?.message.content_str()
+    }
+
+    /// Reasoning content from the first choice's message, if present.
+    pub fn reasoning_content(&self) -> Option<&str> {
+        self.choices.first()?.message.reasoning_content.as_deref()
+    }
+
+    /// Tool calls from the first choice's message. Empty slice if none.
+    pub fn tool_calls(&self) -> &[ToolCall] {
+        self.choices
+            .first()
+            .and_then(|c| c.message.tool_calls.as_deref())
+            .unwrap_or(&[])
+    }
+
+    /// Finish reason from the first choice, if present.
+    pub fn finish_reason(&self) -> Option<&FinishReason> {
+        self.choices.first()?.finish_reason.as_ref()
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Usage {
     pub prompt_tokens: u32,
@@ -355,6 +380,31 @@ pub struct ChatCompletionChunk {
     pub usage: Option<Usage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_fingerprint: Option<String>,
+}
+
+impl ChatCompletionChunk {
+    /// Text delta from the first choice, if present.
+    pub fn content(&self) -> Option<&str> {
+        self.choices.first()?.delta.content.as_deref()
+    }
+
+    /// Reasoning-content delta from the first choice, if present.
+    pub fn reasoning_content(&self) -> Option<&str> {
+        self.choices.first()?.delta.reasoning_content.as_deref()
+    }
+
+    /// Tool-call deltas from the first choice. Empty slice if none.
+    pub fn tool_calls(&self) -> &[ToolCallDelta] {
+        self.choices
+            .first()
+            .and_then(|c| c.delta.tool_calls.as_deref())
+            .unwrap_or(&[])
+    }
+
+    /// Finish reason from the first choice, if present.
+    pub fn finish_reason(&self) -> Option<&FinishReason> {
+        self.choices.first()?.finish_reason.as_ref()
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -243,6 +243,18 @@ impl Message {
     pub fn system(content: impl Into<String>) -> Self {
         Self::with_role(Role::System, content)
     }
+
+    /// Build a `Message` with role `Tool`, setting `tool_call_id` and `name`.
+    pub fn tool(
+        tool_call_id: impl Into<String>,
+        name: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        let mut msg = Self::with_role(Role::Tool, content);
+        msg.tool_call_id = Some(tool_call_id.into());
+        msg.name = Some(name.into());
+        msg
+    }
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- `Message::tool(tool_call_id, name, content)` — rounds out the `user`/`assistant`/`system` constructor set with the remaining common role.
- `Message::content_str()` — returns the `&str` view of the permissive `Option<serde_json::Value>` content field, for the common plain-text case.
- `content`/`reasoning_content`/`tool_calls`/`finish_reason` accessors on `ChatCompletionChunk` and `ChatCompletionResponse` — hides `chunk.choices.first().and_then(|c| c.delta.content.as_deref())` behind `chunk.content()`. `tool_calls` flattens `Option<&[T]>` to `&[T]` so iteration sites don't need a `?`.

Closes #46.

## Test plan

- [x] `cargo check -p crabllm-core`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Downstream consumer (crabtalk) picks up the helpers and drops local reimplementations