### PR TITLE
feat: embedder control-plane surface for MLX + proxy

### DIFF
--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -450,6 +450,7 @@ async fn run<S: Storage + 'static>(
         extensions: Arc::new(extensions),
         storage,
         key_map,
+        usage_events: None,
     };
 
     let app = crabllm_proxy::router(state, admin_routes);

--- a/crates/mlx/src/ffi.rs
+++ b/crates/mlx/src/ffi.rs
@@ -52,6 +52,16 @@ pub struct CrabllmMlxGenerateResult {
     pub error: *mut c_char,
 }
 
+/// Layout mirror of `CrabllmMlxLoadedModel` in `crabllm_mlx.h`.
+/// `memory_bytes` is `size_t` on the C side — `usize` here keeps
+/// the ABI stable on 64-bit platforms (the only target we build).
+#[repr(C)]
+pub struct CrabllmMlxLoadedModel {
+    pub name: *const c_char,
+    pub memory_bytes: usize,
+    pub last_used_unix: i64,
+}
+
 pub type CrabllmMlxTokenFn = unsafe extern "C" fn(*const c_char, *mut c_void) -> c_int;
 
 #[allow(dead_code)] // Session-level FFI is used by tests and as an escape hatch
@@ -110,4 +120,13 @@ unsafe extern "C" {
     pub fn crabllm_mlx_pool_evict(pool: *mut CrabllmMlxPool, model_dir_path: *const c_char);
 
     pub fn crabllm_mlx_pool_stop_all(pool: *mut CrabllmMlxPool);
+
+    pub fn crabllm_mlx_pool_list_loaded(
+        pool: *mut CrabllmMlxPool,
+        out_array: *mut *mut CrabllmMlxLoadedModel,
+        out_count: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> CrabllmMlxStatus;
+
+    pub fn crabllm_mlx_pool_loaded_free(array: *mut CrabllmMlxLoadedModel, count: usize);
 }

--- a/crates/mlx/src/ffi.rs
+++ b/crates/mlx/src/ffi.rs
@@ -117,7 +117,7 @@ unsafe extern "C" {
         result: *mut CrabllmMlxGenerateResult,
     ) -> CrabllmMlxStatus;
 
-    pub fn crabllm_mlx_pool_evict(pool: *mut CrabllmMlxPool, model_dir_path: *const c_char);
+    pub fn crabllm_mlx_pool_evict(pool: *mut CrabllmMlxPool, model_dir_path: *const c_char) -> i32;
 
     pub fn crabllm_mlx_pool_stop_all(pool: *mut CrabllmMlxPool);
 

--- a/crates/mlx/src/pool.rs
+++ b/crates/mlx/src/pool.rs
@@ -148,11 +148,13 @@ impl MlxPool {
         }
     }
 
-    /// Evict a single model.
-    pub(crate) fn evict(&self, model_dir: &str) {
-        if let Ok(c) = CString::new(model_dir) {
-            unsafe { ffi::crabllm_mlx_pool_evict(self.inner.as_ptr(), c.as_ptr()) };
-        }
+    /// Evict a single model. Returns `true` if the slot was present
+    /// before the call (i.e. something was actually unloaded).
+    pub(crate) fn evict(&self, model_dir: &str) -> bool {
+        let Ok(c) = CString::new(model_dir) else {
+            return false;
+        };
+        unsafe { ffi::crabllm_mlx_pool_evict(self.inner.as_ptr(), c.as_ptr()) == 1 }
     }
 
     /// Evict all models and stop the idle monitor.
@@ -164,8 +166,17 @@ impl MlxPool {
     ///
     /// Each returned [`LoadedModel`] is a copy of the Swift-side slot
     /// at snapshot time. Concurrent generate / evict calls race
-    /// cleanly against this — the Swift actor serializes the
-    /// snapshot with every other mutation.
+    /// cleanly against the snapshot's name + timestamp read, but the
+    /// `memory_bytes` field is computed by a filesystem scan that
+    /// happens *outside* the Swift actor to avoid blocking other
+    /// pool operations. If the model directory is wiped between the
+    /// snapshot and the scan — rare, but possible if another thread
+    /// calls `unload` on exactly this slot while a status poll is in
+    /// flight — the scan returns zero. Such zero-byte entries are
+    /// dropped from the result rather than reported as a misleading
+    /// "Qwen · 0 B · 3m ago" row. Genuine empty directories (model
+    /// never successfully loaded) are unlikely and accepting the
+    /// loss there is cheaper than the alternative.
     pub fn loaded_models(&self) -> Result<Vec<LoadedModel>, Error> {
         let mut arr: *mut ffi::CrabllmMlxLoadedModel = ptr::null_mut();
         let mut count: usize = 0;
@@ -187,6 +198,13 @@ impl MlxPool {
         let mut out = Vec::with_capacity(count);
         for i in 0..count {
             let item = unsafe { &*arr.add(i) };
+            // TOCTOU filter: zero memory_bytes means the FS scan
+            // found nothing at the dir (raced with an evict that
+            // cleaned up the cache). Drop the row rather than
+            // surface a misleading entry.
+            if item.memory_bytes == 0 {
+                continue;
+            }
             let name = if item.name.is_null() {
                 String::new()
             } else {

--- a/crates/mlx/src/pool.rs
+++ b/crates/mlx/src/pool.rs
@@ -12,10 +12,23 @@ use crate::session::{
 };
 use crabllm_core::Error;
 use std::{
-    ffi::{CString, c_char},
+    ffi::{CStr, CString, c_char},
     os::raw::c_void,
     ptr,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+/// One entry in [`MlxPool::loaded_models`]'s inventory. `name` is the
+/// local directory path the pool stores the slot under (what was
+/// passed to `generate`). `memory_bytes` is a best-effort weight-file
+/// footprint on disk — the weights dominate MLX's unified-memory
+/// residency, so it's a stable proxy for "how big is this slot".
+#[derive(Debug, Clone)]
+pub struct LoadedModel {
+    pub name: String,
+    pub memory_bytes: u64,
+    pub last_used: SystemTime,
+}
 
 /// Handle to a Swift-side multi-model pool.
 pub struct MlxPool {
@@ -145,6 +158,51 @@ impl MlxPool {
     /// Evict all models and stop the idle monitor.
     pub(crate) fn stop_all(&self) {
         unsafe { ffi::crabllm_mlx_pool_stop_all(self.inner.as_ptr()) };
+    }
+
+    /// Snapshot the pool's loaded-model inventory.
+    ///
+    /// Each returned [`LoadedModel`] is a copy of the Swift-side slot
+    /// at snapshot time. Concurrent generate / evict calls race
+    /// cleanly against this — the Swift actor serializes the
+    /// snapshot with every other mutation.
+    pub fn loaded_models(&self) -> Result<Vec<LoadedModel>, Error> {
+        let mut arr: *mut ffi::CrabllmMlxLoadedModel = ptr::null_mut();
+        let mut count: usize = 0;
+        let mut err: *mut c_char = ptr::null_mut();
+        let status = unsafe {
+            ffi::crabllm_mlx_pool_list_loaded(self.inner.as_ptr(), &mut arr, &mut count, &mut err)
+        };
+        if status != ffi::CRABLLM_MLX_OK {
+            let msg = unsafe { take_owned_c_string(err) };
+            return Err(translate_status(status, msg));
+        }
+
+        // Empty inventory: Swift may leave arr NULL; count == 0.
+        // Nothing to free and nothing to copy.
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            let item = unsafe { &*arr.add(i) };
+            let name = if item.name.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(item.name) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            let last_used = UNIX_EPOCH + Duration::from_secs(item.last_used_unix.max(0) as u64);
+            out.push(LoadedModel {
+                name,
+                memory_bytes: item.memory_bytes as u64,
+                last_used,
+            });
+        }
+        unsafe { ffi::crabllm_mlx_pool_loaded_free(arr, count) };
+        Ok(out)
     }
 }
 

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     download,
-    pool::MlxPool,
+    pool::{LoadedModel, MlxPool},
     session::{GenerateOptions, GenerateRequest},
 };
 use crabllm_core::{
@@ -41,6 +41,12 @@ impl std::fmt::Debug for MlxProvider {
 impl MlxProvider {
     pub fn new(pool: Arc<MlxPool>) -> Self {
         Self { pool }
+    }
+
+    /// Snapshot the pool's loaded-model inventory. See
+    /// [`MlxPool::loaded_models`] for the full contract.
+    pub fn loaded_models(&self) -> Result<Vec<LoadedModel>, Error> {
+        self.pool.loaded_models()
     }
 
     /// Resolve a model name to a local directory path.

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -50,19 +50,48 @@ impl MlxProvider {
     /// is not cached. Use [`download::download_model`] to download
     /// explicitly before calling the provider.
     fn resolve_model_dir(&self, model_id: &str) -> Result<PathBuf, Error> {
-        let as_path = Path::new(model_id);
-        if as_path.exists() && as_path.is_dir() {
-            return Ok(as_path.to_path_buf());
-        }
-
-        let repo_id = crate::registry::resolve(model_id).unwrap_or(model_id);
-
-        download::cached_model_path(repo_id).ok_or_else(|| {
+        self.lookup_cached_model_dir(model_id).ok_or_else(|| {
+            let repo_id = crate::registry::resolve(model_id).unwrap_or(model_id);
             Error::Internal(format!(
                 "mlx: model not downloaded: {repo_id}. \
                  Use download::download_model() first."
             ))
         })
+    }
+
+    fn lookup_cached_model_dir(&self, model_id: &str) -> Option<PathBuf> {
+        let as_path = Path::new(model_id);
+        if as_path.exists() && as_path.is_dir() {
+            return Some(as_path.to_path_buf());
+        }
+        let repo_id = crate::registry::resolve(model_id).unwrap_or(model_id);
+        download::cached_model_path(repo_id)
+    }
+
+    /// Unload a model from the pool.
+    ///
+    /// Accepts the same inputs as a generate call: a local directory
+    /// path, a full HuggingFace repo id, or a registry alias. If the
+    /// model is not cached on disk (never downloaded, already wiped)
+    /// this is a no-op — the pool's evict is already idempotent and a
+    /// caller asking to unload an unloaded model got what they wanted.
+    ///
+    /// Generations already in flight for this model continue
+    /// uninterrupted: the Swift side holds a strong reference to the
+    /// `ModelContainer` for the duration of the call, so dropping it
+    /// from the pool's slot table only releases the pool's reference.
+    /// The next request for this model reloads from disk.
+    pub fn unload(&self, model_id: &str) {
+        if let Some(dir) = self.lookup_cached_model_dir(model_id) {
+            self.pool.evict(&dir.to_string_lossy());
+        }
+    }
+
+    /// Evict every loaded model and stop the idle monitor. The pool
+    /// handle remains valid — subsequent requests will load models
+    /// on demand but no new idle sweep will run.
+    pub fn unload_all(&self) {
+        self.pool.stop_all();
     }
 }
 

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -77,20 +77,24 @@ impl MlxProvider {
     /// Unload a model from the pool.
     ///
     /// Accepts the same inputs as a generate call: a local directory
-    /// path, a full HuggingFace repo id, or a registry alias. If the
-    /// model is not cached on disk (never downloaded, already wiped)
-    /// this is a no-op — the pool's evict is already idempotent and a
-    /// caller asking to unload an unloaded model got what they wanted.
+    /// path, a full HuggingFace repo id, or a registry alias.
+    ///
+    /// Returns `true` if the slot was loaded in the pool at the
+    /// moment of the call and was actually evicted; `false` if the
+    /// model was not cached on disk or was cached but not loaded in
+    /// the pool. Downstream admin endpoints can map `false` to a
+    /// 404 "not loaded" response and `true` to a 200 "evicted".
     ///
     /// Generations already in flight for this model continue
     /// uninterrupted: the Swift side holds a strong reference to the
     /// `ModelContainer` for the duration of the call, so dropping it
     /// from the pool's slot table only releases the pool's reference.
     /// The next request for this model reloads from disk.
-    pub fn unload(&self, model_id: &str) {
-        if let Some(dir) = self.lookup_cached_model_dir(model_id) {
-            self.pool.evict(&dir.to_string_lossy());
-        }
+    pub fn unload(&self, model_id: &str) -> bool {
+        let Some(dir) = self.lookup_cached_model_dir(model_id) else {
+            return false;
+        };
+        self.pool.evict(&dir.to_string_lossy())
     }
 
     /// Evict every loaded model and stop the idle monitor. The pool

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -1,4 +1,4 @@
-use crate::{AppState, auth::KeyName};
+use crate::{AppState, auth::KeyName, state::UsageEvent};
 use axum::{
     Extension, Json,
     extract::{Multipart, State},
@@ -17,10 +17,10 @@ use crabllm_provider::Deployment;
 use futures::StreamExt;
 use rand::Rng;
 use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU32, Ordering},
 };
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 fn record_duration(ctx: &RequestContext, status: &'static str) {
     metrics::histogram!("crabllm_request_duration_seconds",
@@ -59,6 +59,41 @@ fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
             "direction" => "completion",
         )
         .increment(completion as u64);
+    }
+}
+
+fn emit_usage<S: Storage, P: Provider>(
+    state: &AppState<S, P>,
+    ctx: &RequestContext,
+    endpoint: &'static str,
+    tokens_in: u32,
+    tokens_out: u32,
+    status: u16,
+    error: Option<String>,
+) {
+    let Some(tx) = state.usage_events.as_ref() else {
+        return;
+    };
+    let _ = tx.send(UsageEvent {
+        timestamp: SystemTime::now(),
+        request_id: ctx.request_id.clone(),
+        key_name: ctx.key_name.clone(),
+        model: ctx.model.clone(),
+        provider: ctx.provider.clone(),
+        endpoint,
+        tokens_in,
+        tokens_out,
+        duration_ms: ctx.started_at.elapsed().as_millis() as u64,
+        status,
+        error,
+    });
+}
+
+fn http_status_from_error(e: &crabllm_core::Error) -> u16 {
+    match e {
+        crabllm_core::Error::Provider { status, .. } => *status,
+        crabllm_core::Error::Timeout => 504,
+        _ => 500,
     }
 }
 
@@ -130,14 +165,30 @@ where
                     let extensions = state.extensions.clone();
                     let ctx = Arc::new(ctx);
                     let errored = Arc::new(AtomicBool::new(false));
+                    // Relaxed loads/stores on these atomics are sound: the
+                    // `done` stream-once only polls after the upstream
+                    // `.then` stream has yielded `Poll::Ready(None)`, which
+                    // happens-after every per-chunk future resolves. The
+                    // `.chain` combinator provides the ordering; the atomic
+                    // type is just for interior mutability across clones.
+                    let tokens_in = Arc::new(AtomicU32::new(0));
+                    let tokens_out = Arc::new(AtomicU32::new(0));
+                    let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
                     let ctx_done = ctx.clone();
                     let errored_done = errored.clone();
+                    let tokens_in_done = tokens_in.clone();
+                    let tokens_out_done = tokens_out.clone();
+                    let first_error_done = first_error.clone();
+                    let state_done = state.clone();
 
                     let observed = stream.then(move |result| {
                         let extensions = extensions.clone();
                         let ctx = ctx.clone();
                         let errored = errored.clone();
+                        let tokens_in = tokens_in.clone();
+                        let tokens_out = tokens_out.clone();
+                        let first_error = first_error.clone();
                         async move {
                             match &result {
                                 Ok(chunk) => {
@@ -149,6 +200,9 @@ where
                                             usage.prompt_tokens,
                                             usage.completion_tokens,
                                         );
+                                        tokens_in.store(usage.prompt_tokens, Ordering::Relaxed);
+                                        tokens_out
+                                            .store(usage.completion_tokens, Ordering::Relaxed);
                                     }
                                     for ext in extensions.iter() {
                                         ext.on_chunk(&ctx, chunk).await;
@@ -156,6 +210,12 @@ where
                                 }
                                 Err(error) => {
                                     errored.store(true, Ordering::Relaxed);
+                                    {
+                                        let mut slot = first_error.lock().unwrap();
+                                        if slot.is_none() {
+                                            *slot = Some(error.to_string());
+                                        }
+                                    }
                                     for ext in extensions.iter() {
                                         ext.on_error(&ctx, error).await;
                                     }
@@ -181,13 +241,22 @@ where
                     });
 
                     // Record duration once when the stream terminates.
+                    // The wire status is always 200 here — headers were
+                    // sent before the first chunk, so mid-stream failures
+                    // surface via UsageEvent::error, not status.
                     let done = futures::stream::once(async move {
-                        let status = if errored_done.load(Ordering::Relaxed) {
-                            "5xx"
-                        } else {
-                            "2xx"
-                        };
-                        record_duration(&ctx_done, status);
+                        let errored = errored_done.load(Ordering::Relaxed);
+                        record_duration(&ctx_done, if errored { "5xx" } else { "2xx" });
+                        let error = first_error_done.lock().unwrap().take();
+                        emit_usage(
+                            &state_done,
+                            &ctx_done,
+                            "chat.completions",
+                            tokens_in_done.load(Ordering::Relaxed),
+                            tokens_out_done.load(Ordering::Relaxed),
+                            200,
+                            error,
+                        );
                         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
                     });
                     let full_stream = sse_stream.chain(done);
@@ -206,6 +275,15 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, "5xx");
+        emit_usage(
+            &state,
+            &ctx,
+            "chat.completions",
+            0,
+            0,
+            http_status_from_error(&e),
+            Some(e.to_string()),
+        );
         error_response(e)
     } else {
         // Non-streaming: check cache first.
@@ -221,10 +299,16 @@ where
         for deployment in &deployments {
             match try_chat_with_retries(deployment, &request).await {
                 Ok(resp) => {
-                    if let Some(ref usage) = resp.usage {
-                        record_tokens(&ctx, usage.prompt_tokens, usage.completion_tokens);
+                    let (pt, ct) = resp
+                        .usage
+                        .as_ref()
+                        .map(|u| (u.prompt_tokens, u.completion_tokens))
+                        .unwrap_or((0, 0));
+                    if pt > 0 || ct > 0 {
+                        record_tokens(&ctx, pt, ct);
                     }
                     record_duration(&ctx, "2xx");
+                    emit_usage(&state, &ctx, "chat.completions", pt, ct, 200, None);
                     for ext in state.extensions.iter() {
                         ext.on_response(&ctx, &request, &resp).await;
                     }
@@ -240,6 +324,15 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, error_status(&e));
+        emit_usage(
+            &state,
+            &ctx,
+            "chat.completions",
+            0,
+            0,
+            http_status_from_error(&e),
+            Some(e.to_string()),
+        );
         error_response(e)
     }
 }
@@ -300,6 +393,15 @@ where
         match try_embedding_with_retries(deployment, &request).await {
             Ok(resp) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(
+                    &state,
+                    &ctx,
+                    "embeddings",
+                    resp.usage.prompt_tokens,
+                    0,
+                    200,
+                    None,
+                );
                 return Json(resp).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -312,6 +414,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "embeddings",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -399,6 +510,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "images.generations", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -411,6 +523,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "images.generations",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -475,6 +596,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "audio.speech", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -487,6 +609,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "audio.speech",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -601,6 +732,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "audio.transcriptions", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -613,6 +745,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "audio.transcriptions",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -97,6 +97,23 @@ fn http_status_from_error(e: &crabllm_core::Error) -> u16 {
     }
 }
 
+fn emit_usage_error<S: Storage, P: Provider>(
+    state: &AppState<S, P>,
+    ctx: &RequestContext,
+    endpoint: &'static str,
+    e: &crabllm_core::Error,
+) {
+    emit_usage(
+        state,
+        ctx,
+        endpoint,
+        0,
+        0,
+        http_status_from_error(e),
+        Some(e.to_string()),
+    );
+}
+
 /// POST /v1/chat/completions
 pub async fn chat_completions<S, P>(
     State(state): State<AppState<S, P>>,
@@ -165,12 +182,13 @@ where
                     let extensions = state.extensions.clone();
                     let ctx = Arc::new(ctx);
                     let errored = Arc::new(AtomicBool::new(false));
-                    // Relaxed loads/stores on these atomics are sound: the
-                    // `done` stream-once only polls after the upstream
-                    // `.then` stream has yielded `Poll::Ready(None)`, which
-                    // happens-after every per-chunk future resolves. The
-                    // `.chain` combinator provides the ordering; the atomic
-                    // type is just for interior mutability across clones.
+                    // `Ordering::Relaxed` is sufficient because the stream
+                    // is polled by a single task — every store in the
+                    // per-chunk future is sequenced-before the `done`
+                    // terminator's load via tokio's normal single-task
+                    // poll ordering. No cross-thread visibility problem
+                    // exists; the atomics only provide interior
+                    // mutability across closure clones.
                     let tokens_in = Arc::new(AtomicU32::new(0));
                     let tokens_out = Arc::new(AtomicU32::new(0));
                     let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
@@ -240,21 +258,28 @@ where
                         }
                     });
 
-                    // Record duration once when the stream terminates.
-                    // The wire status is always 200 here — headers were
-                    // sent before the first chunk, so mid-stream failures
-                    // surface via UsageEvent::error, not status.
+                    // Record duration + emit usage once when the stream
+                    // terminates. Status codes:
+                    //   - 200: clean stream, no errors
+                    //   - 0:   mid-stream failure after headers went out.
+                    //          The real wire status was 200 (headers
+                    //          shipped before the break), but reporting
+                    //          200 again here would let consumers miss
+                    //          the failure without also inspecting the
+                    //          `error` field. 0 is a clear sentinel
+                    //          meaning "not a real HTTP response".
                     let done = futures::stream::once(async move {
                         let errored = errored_done.load(Ordering::Relaxed);
                         record_duration(&ctx_done, if errored { "5xx" } else { "2xx" });
                         let error = first_error_done.lock().unwrap().take();
+                        let status = if errored { 0 } else { 200 };
                         emit_usage(
                             &state_done,
                             &ctx_done,
                             "chat.completions",
                             tokens_in_done.load(Ordering::Relaxed),
                             tokens_out_done.load(Ordering::Relaxed),
-                            200,
+                            status,
                             error,
                         );
                         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
@@ -275,15 +300,7 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, "5xx");
-        emit_usage(
-            &state,
-            &ctx,
-            "chat.completions",
-            0,
-            0,
-            http_status_from_error(&e),
-            Some(e.to_string()),
-        );
+        emit_usage_error(&state, &ctx, "chat.completions", &e);
         error_response(e)
     } else {
         // Non-streaming: check cache first.
@@ -324,15 +341,7 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, error_status(&e));
-        emit_usage(
-            &state,
-            &ctx,
-            "chat.completions",
-            0,
-            0,
-            http_status_from_error(&e),
-            Some(e.to_string()),
-        );
+        emit_usage_error(&state, &ctx, "chat.completions", &e);
         error_response(e)
     }
 }
@@ -414,15 +423,7 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
-    emit_usage(
-        &state,
-        &ctx,
-        "embeddings",
-        0,
-        0,
-        http_status_from_error(&e),
-        Some(e.to_string()),
-    );
+    emit_usage_error(&state, &ctx, "embeddings", &e);
     error_response(e)
 }
 
@@ -523,15 +524,7 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
-    emit_usage(
-        &state,
-        &ctx,
-        "images.generations",
-        0,
-        0,
-        http_status_from_error(&e),
-        Some(e.to_string()),
-    );
+    emit_usage_error(&state, &ctx, "images.generations", &e);
     error_response(e)
 }
 
@@ -609,15 +602,7 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
-    emit_usage(
-        &state,
-        &ctx,
-        "audio.speech",
-        0,
-        0,
-        http_status_from_error(&e),
-        Some(e.to_string()),
-    );
+    emit_usage_error(&state, &ctx, "audio.speech", &e);
     error_response(e)
 }
 
@@ -745,15 +730,7 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
-    emit_usage(
-        &state,
-        &ctx,
-        "audio.transcriptions",
-        0,
-        0,
-        http_status_from_error(&e),
-        Some(e.to_string()),
-    );
+    emit_usage_error(&state, &ctx, "audio.transcriptions", &e);
     error_response(e)
 }
 

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -8,7 +8,7 @@ use axum::{
 use crabllm_core::{Provider, Storage};
 
 pub use auth::KeyName;
-pub use state::AppState;
+pub use state::{AppState, UsageEvent};
 
 pub mod admin;
 pub mod auth;

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -3,7 +3,41 @@ use crabllm_provider::ProviderRegistry;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::SystemTime,
 };
+use tokio::sync::broadcast;
+
+/// Per-request event emitted after a request completes. Embedders
+/// subscribe to the [`AppState::usage_events`] broadcast channel to
+/// observe live traffic without scraping the Prometheus endpoint.
+#[derive(Debug, Clone)]
+pub struct UsageEvent {
+    pub timestamp: SystemTime,
+    pub request_id: String,
+    pub key_name: Option<String>,
+    pub model: String,
+    pub provider: String,
+    /// Logical endpoint: `"chat.completions"`, `"embeddings"`,
+    /// `"images.generations"`, `"audio.speech"`, `"audio.transcriptions"`.
+    pub endpoint: &'static str,
+    /// Prompt / input tokens. For embeddings this is the input token
+    /// count; for image / audio endpoints it's 0.
+    pub tokens_in: u32,
+    /// Completion / output tokens. 0 for endpoints that don't generate
+    /// tokens (embeddings, images, audio).
+    pub tokens_out: u32,
+    pub duration_ms: u64,
+    /// The wire HTTP status the client observed. For streaming chat
+    /// this is always 200 on any connection that produced at least
+    /// one chunk — mid-stream failures surface in [`Self::error`]
+    /// instead, since the response headers went out as 200 OK before
+    /// the stream broke.
+    pub status: u16,
+    /// `Some(msg)` if the request failed. For streaming chat this
+    /// includes the case where the stream started successfully (status
+    /// == 200) but errored mid-response.
+    pub error: Option<String>,
+}
 
 /// Shared application state passed to all handlers.
 ///
@@ -19,6 +53,12 @@ pub struct AppState<S: Storage, P: Provider> {
     /// Precomputed token → key name lookup for O(1) auth.
     /// Wrapped in RwLock to support runtime key management.
     pub key_map: Arc<RwLock<HashMap<String, String>>>,
+    /// Optional broadcast sink for per-request [`UsageEvent`]s. `None`
+    /// is a no-op — the standalone `crabllm serve` binary leaves it
+    /// unset and behavior is unchanged. Embedders that want live
+    /// traffic construct a sender, pass `Some(sender.clone())`, and
+    /// call `sender.subscribe()` to observe events.
+    pub usage_events: Option<broadcast::Sender<UsageEvent>>,
 }
 
 impl<S: Storage, P: Provider> Clone for AppState<S, P> {
@@ -29,6 +69,7 @@ impl<S: Storage, P: Provider> Clone for AppState<S, P> {
             extensions: self.extensions.clone(),
             storage: self.storage.clone(),
             key_map: self.key_map.clone(),
+            usage_events: self.usage_events.clone(),
         }
     }
 }

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -27,15 +27,17 @@ pub struct UsageEvent {
     /// tokens (embeddings, images, audio).
     pub tokens_out: u32,
     pub duration_ms: u64,
-    /// The wire HTTP status the client observed. For streaming chat
-    /// this is always 200 on any connection that produced at least
-    /// one chunk — mid-stream failures surface in [`Self::error`]
-    /// instead, since the response headers went out as 200 OK before
-    /// the stream broke.
+    /// The wire HTTP status the client observed, or `0` when a
+    /// streaming chat response sent 200 OK headers and then broke
+    /// mid-stream. `0` is a sentinel meaning "not a real HTTP
+    /// response" — consumers branching on `status` alone can
+    /// distinguish a clean 200 from a failed stream without having
+    /// to inspect [`Self::error`]. For non-streaming requests
+    /// `status` is always the real HTTP code the client saw.
     pub status: u16,
-    /// `Some(msg)` if the request failed. For streaming chat this
-    /// includes the case where the stream started successfully (status
-    /// == 200) but errored mid-response.
+    /// `Some(msg)` if the request failed. Set alongside `status == 0`
+    /// for mid-stream streaming failures; set alongside a real error
+    /// status (4xx/5xx) for pre-stream and non-streaming failures.
     pub error: Option<String>,
 }
 

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -1,0 +1,215 @@
+//! Integration test for the [`UsageEvent`] broadcast channel.
+//!
+//! Drives a real request through the proxy router with a fake
+//! provider and storage, subscribes to `usage_events`, and asserts
+//! that exactly one event arrives with the expected shape.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use crabllm_core::{
+    BoxFuture, BoxStream, ChatCompletionRequest, ChatCompletionResponse, Choice, Error,
+    FinishReason, GatewayConfig, KvPairs, Message, Prefix, Provider, Role, Storage, Usage,
+};
+use crabllm_provider::{Deployment, ProviderRegistry};
+use crabllm_proxy::{AppState, UsageEvent, router};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+
+struct FakeProvider;
+
+impl Provider for FakeProvider {
+    async fn chat_completion(
+        &self,
+        request: &ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, Error> {
+        Ok(ChatCompletionResponse {
+            id: "chatcmpl-test".into(),
+            object: "chat.completion".into(),
+            created: 0,
+            model: request.model.clone(),
+            choices: vec![Choice {
+                index: 0,
+                message: Message {
+                    role: Role::Assistant,
+                    content: Some(serde_json::Value::String("hi".into())),
+                    tool_calls: None,
+                    tool_call_id: None,
+                    name: None,
+                    reasoning_content: None,
+                    extra: Default::default(),
+                },
+                finish_reason: Some(FinishReason::Stop),
+                logprobs: None,
+            }],
+            usage: Some(Usage {
+                prompt_tokens: 11,
+                completion_tokens: 22,
+                total_tokens: 33,
+                completion_tokens_details: None,
+                prompt_cache_hit_tokens: None,
+                prompt_cache_miss_tokens: None,
+            }),
+            system_fingerprint: None,
+        })
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _request: &ChatCompletionRequest,
+    ) -> Result<BoxStream<'static, Result<crabllm_core::ChatCompletionChunk, Error>>, Error> {
+        Err(Error::not_implemented("stream"))
+    }
+}
+
+struct FakeStorage;
+
+impl Storage for FakeStorage {
+    fn get(&self, _key: &[u8]) -> BoxFuture<'_, Result<Option<Vec<u8>>, Error>> {
+        Box::pin(async { Ok(None) })
+    }
+    fn set(&self, _key: &[u8], _value: Vec<u8>) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(async { Ok(()) })
+    }
+    fn increment(&self, _key: &[u8], _delta: i64) -> BoxFuture<'_, Result<i64, Error>> {
+        Box::pin(async { Ok(0) })
+    }
+    fn list(&self, _prefix: &Prefix) -> BoxFuture<'_, Result<KvPairs, Error>> {
+        Box::pin(async { Ok(KvPairs::default()) })
+    }
+    fn delete(&self, _key: &[u8]) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn empty_config() -> GatewayConfig {
+    GatewayConfig {
+        listen: String::new(),
+        providers: HashMap::new(),
+        keys: Vec::new(),
+        extensions: None,
+        storage: None,
+        aliases: HashMap::new(),
+        pricing: HashMap::new(),
+        admin_token: None,
+        shutdown_timeout: 30,
+        llamacpp: None,
+    }
+}
+
+fn build_state(tx: broadcast::Sender<UsageEvent>) -> AppState<FakeStorage, FakeProvider> {
+    let mut providers: HashMap<String, Vec<Arc<Deployment<FakeProvider>>>> = HashMap::new();
+    providers.insert(
+        "fake-model".to_string(),
+        vec![Arc::new(Deployment {
+            provider: FakeProvider,
+            weight: 1,
+            max_retries: 0,
+            timeout: Duration::from_secs(5),
+        })],
+    );
+    let mut model_providers = HashMap::new();
+    model_providers.insert("fake-model".to_string(), "fake".to_string());
+
+    let registry = ProviderRegistry::new(providers, HashMap::new(), model_providers);
+
+    AppState {
+        registry,
+        config: empty_config(),
+        extensions: Arc::new(Vec::new()),
+        storage: Arc::new(FakeStorage),
+        key_map: Arc::new(RwLock::new(HashMap::new())),
+        usage_events: Some(tx),
+    }
+}
+
+#[tokio::test]
+async fn chat_completion_emits_one_usage_event() {
+    let (tx, mut rx) = broadcast::channel::<UsageEvent>(16);
+    let state = build_state(tx);
+    let app = router(state, vec![]);
+
+    let body = serde_json::json!({
+        "model": "fake-model",
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let event = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("timed out waiting for UsageEvent")
+        .expect("broadcast closed");
+
+    assert_eq!(event.endpoint, "chat.completions");
+    assert_eq!(event.model, "fake-model");
+    assert_eq!(event.provider, "fake");
+    assert_eq!(event.tokens_in, 11);
+    assert_eq!(event.tokens_out, 22);
+    assert_eq!(event.status, 200);
+    assert!(event.error.is_none());
+
+    // No duplicate emission. Either a timeout (channel still open but
+    // silent) or a Closed error (all senders dropped after the handler
+    // returned) is acceptable — both mean "no further events".
+    match tokio::time::timeout(Duration::from_millis(50), rx.recv()).await {
+        Err(_) => {}                                          // timeout
+        Ok(Err(broadcast::error::RecvError::Closed)) => {}    // channel closed
+        Ok(Err(broadcast::error::RecvError::Lagged(_))) => {} // treat as no extra
+        Ok(Ok(evt)) => panic!("unexpected second event: {:?}", evt),
+    }
+}
+
+#[tokio::test]
+async fn none_usage_events_is_zero_cost() {
+    let mut providers: HashMap<String, Vec<Arc<Deployment<FakeProvider>>>> = HashMap::new();
+    providers.insert(
+        "fake-model".to_string(),
+        vec![Arc::new(Deployment {
+            provider: FakeProvider,
+            weight: 1,
+            max_retries: 0,
+            timeout: Duration::from_secs(5),
+        })],
+    );
+    let mut model_providers = HashMap::new();
+    model_providers.insert("fake-model".to_string(), "fake".to_string());
+    let registry = ProviderRegistry::new(providers, HashMap::new(), model_providers);
+
+    let state = AppState::<FakeStorage, FakeProvider> {
+        registry,
+        config: empty_config(),
+        extensions: Arc::new(Vec::new()),
+        storage: Arc::new(FakeStorage),
+        key_map: Arc::new(RwLock::new(HashMap::new())),
+        usage_events: None,
+    };
+
+    let app = router(state, vec![]);
+    let body = serde_json::json!({
+        "model": "fake-model",
+        "messages": [{ "role": "user", "content": "hi" }],
+    });
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/mlx/Sources/CrabllmMlx/Pool.swift
+++ b/mlx/Sources/CrabllmMlx/Pool.swift
@@ -67,6 +67,17 @@ actor MlxPool {
         monitorTask = nil
     }
 
+    /// Snapshot every loaded slot's name and last-used time. Returns
+    /// the minimum the FFI wrapper needs to build a `LoadedModel`
+    /// array; memory-footprint computation is a filesystem scan and
+    /// runs *outside* the actor so it doesn't block concurrent
+    /// generate / evict calls.
+    func snapshot() -> [(name: String, lastUsedUnix: Int64)] {
+        models.map { (dir, entry) in
+            (name: dir, lastUsedUnix: Int64(entry.lastUsed.timeIntervalSince1970))
+        }
+    }
+
     private func evictExpired() {
         let now = Date()
         let expired = models.filter { now.timeIntervalSince($0.value.lastUsed) > idleTimeout }
@@ -247,4 +258,146 @@ public func crabllm_mlx_pool_stop_all(_ pool: UnsafeMutableRawPointer?) {
     guard let pool = pool else { return }
     let actor = Unmanaged<MlxPoolBox>.fromOpaque(pool).takeUnretainedValue().pool
     try? blockingAwait { await actor.stopAll() }
+}
+
+// MARK: - Loaded model inventory
+//
+// The C ABI struct `CrabllmMlxLoadedModel` is written via byte-offset
+// stores against an `UnsafeMutableRawPointer` buffer, mirroring the
+// `CrabllmMlxGenerateResult` pattern in Session.swift. We don't define
+// a Swift struct for it because plain Swift structs have no layout
+// guarantee — smoke.c pins the C-side layout, and these offset
+// constants are the Swift-side mirror pinned to those same values.
+
+private let loadedOffsetName = 0
+private let loadedOffsetMemoryBytes = 8
+private let loadedOffsetLastUsedUnix = 16
+private let loadedModelStride = 24
+
+/// Sum of weight-file sizes under a model directory. Best-effort:
+/// unreadable / missing paths contribute zero. Runs outside the actor
+/// so concurrent generate/evict aren't blocked on filesystem I/O.
+private func bestEffortWeightBytes(atPath dir: String) -> UInt64 {
+    let fm = FileManager.default
+    let url = URL(fileURLWithPath: dir)
+    guard let entries = try? fm.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: [.fileSizeKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return 0
+    }
+    var total: UInt64 = 0
+    for entry in entries {
+        let ext = entry.pathExtension.lowercased()
+        guard ext == "safetensors" || ext == "bin" || ext == "gguf" else { continue }
+        if let size = try? entry.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+            total &+= UInt64(size)
+        }
+    }
+    return total
+}
+
+/// Free all strdup'd name pointers in a loaded-model buffer, then
+/// deallocate the buffer. `count` must match the allocation.
+private func loadedBufferFreeNames(_ buf: UnsafeMutableRawPointer, _ count: Int) {
+    for i in 0..<count {
+        let slot = buf.advanced(by: i * loadedModelStride + loadedOffsetName)
+            .assumingMemoryBound(to: UnsafeMutablePointer<CChar>?.self)
+        if let name = slot.pointee {
+            free(UnsafeMutableRawPointer(name))
+            slot.pointee = nil
+        }
+    }
+}
+
+@_cdecl("crabllm_mlx_pool_list_loaded")
+public func crabllm_mlx_pool_list_loaded(
+    _ pool: UnsafeMutableRawPointer?,
+    _ outArray: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ outCount: UnsafeMutablePointer<Int>?,
+    _ outError: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Int32 {
+    guard let outArray = outArray, let outCount = outCount else {
+        if let outError = outError {
+            outError.pointee = cString("out_array / out_count is NULL")
+        }
+        return CRABLLM_MLX_ERR_INVALID_ARG
+    }
+    outArray.pointee = nil
+    outCount.pointee = 0
+
+    guard let pool = pool else {
+        if let outError = outError {
+            outError.pointee = cString("pool is NULL")
+        }
+        return CRABLLM_MLX_ERR_INVALID_ARG
+    }
+
+    let actor = Unmanaged<MlxPoolBox>.fromOpaque(pool).takeUnretainedValue().pool
+    let snapshot: [(name: String, lastUsedUnix: Int64)]
+    do {
+        snapshot = try blockingAwait { await actor.snapshot() }
+    } catch {
+        if let outError = outError {
+            outError.pointee = cString("pool list_loaded error: \(error)")
+        }
+        return CRABLLM_MLX_ERR_UNKNOWN
+    }
+
+    let count = snapshot.count
+    if count == 0 {
+        return CRABLLM_MLX_OK
+    }
+
+    // Compute memory footprints outside the actor — each one is a
+    // FileManager scan, and we don't want to serialize all pool
+    // operations behind a directory enumeration.
+    let memoryBytes: [UInt64] = snapshot.map { bestEffortWeightBytes(atPath: $0.name) }
+
+    // Raw-byte buffer; field layout is pinned by smoke.c's
+    // _Static_assert on the C side and the `loadedOffset*` constants
+    // on this side.
+    let buf = UnsafeMutableRawPointer.allocate(
+        byteCount: count * loadedModelStride,
+        alignment: MemoryLayout<UInt64>.alignment
+    )
+    // Zero the buffer so partial-failure cleanup sees NULL name slots.
+    buf.initializeMemory(as: UInt8.self, repeating: 0, count: count * loadedModelStride)
+
+    for (idx, entry) in snapshot.enumerated() {
+        guard let namePtr = cString(entry.name) else {
+            // strdup OOM: release any names we've already written,
+            // deallocate, and report failure.
+            loadedBufferFreeNames(buf, idx)
+            buf.deallocate()
+            if let outError = outError {
+                outError.pointee = cString("pool list_loaded: out of memory")
+            }
+            return CRABLLM_MLX_ERR_UNKNOWN
+        }
+        let base = buf.advanced(by: idx * loadedModelStride)
+        base.advanced(by: loadedOffsetName)
+            .assumingMemoryBound(to: UnsafeMutablePointer<CChar>?.self)
+            .pointee = namePtr
+        base.advanced(by: loadedOffsetMemoryBytes)
+            .assumingMemoryBound(to: UInt.self)
+            .pointee = UInt(memoryBytes[idx])
+        base.advanced(by: loadedOffsetLastUsedUnix)
+            .assumingMemoryBound(to: Int64.self)
+            .pointee = entry.lastUsedUnix
+    }
+    outArray.pointee = buf
+    outCount.pointee = count
+    return CRABLLM_MLX_OK
+}
+
+@_cdecl("crabllm_mlx_pool_loaded_free")
+public func crabllm_mlx_pool_loaded_free(
+    _ array: UnsafeMutableRawPointer?,
+    _ count: Int
+) {
+    guard let array = array else { return }
+    loadedBufferFreeNames(array, count)
+    array.deallocate()
 }

--- a/mlx/Sources/CrabllmMlx/Pool.swift
+++ b/mlx/Sources/CrabllmMlx/Pool.swift
@@ -57,8 +57,9 @@ actor MlxPool {
         return container
     }
 
-    func evict(_ modelDir: String) {
-        models.removeValue(forKey: modelDir)
+    /// Returns `true` if the slot was present before this call.
+    func evict(_ modelDir: String) -> Bool {
+        models.removeValue(forKey: modelDir) != nil
     }
 
     func stopAll() {
@@ -247,10 +248,16 @@ public func crabllm_mlx_pool_generate_stream(
 public func crabllm_mlx_pool_evict(
     _ pool: UnsafeMutableRawPointer?,
     _ modelDirPath: UnsafePointer<CChar>?
-) {
-    guard let pool = pool, let dir = swiftString(modelDirPath) else { return }
+) -> Int32 {
+    guard let pool = pool, let dir = swiftString(modelDirPath) else { return 0 }
     let actor = Unmanaged<MlxPoolBox>.fromOpaque(pool).takeUnretainedValue().pool
-    try? blockingAwait { await actor.evict(dir) }
+    let wasPresent: Bool
+    do {
+        wasPresent = try blockingAwait { await actor.evict(dir) }
+    } catch {
+        return 0
+    }
+    return wasPresent ? 1 : 0
 }
 
 @_cdecl("crabllm_mlx_pool_stop_all")

--- a/mlx/include/crabllm_mlx.h
+++ b/mlx/include/crabllm_mlx.h
@@ -259,6 +259,50 @@ void crabllm_mlx_pool_evict(CrabllmMlxPool *pool, const char *model_dir_path);
 /* Evict all models and stop the idle monitor. */
 void crabllm_mlx_pool_stop_all(CrabllmMlxPool *pool);
 
+/*
+ * One entry in the pool's loaded-model inventory. Ownership: returned
+ * by crabllm_mlx_pool_list_loaded in a caller-owned array that must
+ * be released with crabllm_mlx_pool_loaded_free. `name` is a null-
+ * terminated UTF-8 string (the local directory path the pool stores
+ * the slot under). `memory_bytes` is a best-effort resident footprint
+ * — currently the sum of weight-file sizes on disk (.safetensors /
+ * .bin / .gguf), which dominates MLX's unified-memory footprint.
+ * `last_used_unix` is seconds since the epoch of the last generate
+ * call that touched the slot.
+ *
+ * Field order is chosen to eliminate padding on 64-bit: 8, 8, 8.
+ */
+typedef struct {
+    const char *name;
+    size_t memory_bytes;
+    int64_t last_used_unix;
+} CrabllmMlxLoadedModel;
+
+/*
+ * Snapshot the pool's loaded-model inventory.
+ *
+ * On success, `*out_array` points to a newly allocated array of
+ * `*out_count` `CrabllmMlxLoadedModel` entries; the caller owns the
+ * array and every `name` pointer inside it, and must release the
+ * whole thing via `crabllm_mlx_pool_loaded_free`. On empty pool,
+ * `*out_count == 0` and `*out_array` may be NULL.
+ *
+ * Blocking. Call from a background thread. Actor-isolated: races
+ * cleanly against concurrent generate / evict calls.
+ */
+CrabllmMlxStatus crabllm_mlx_pool_list_loaded(
+    CrabllmMlxPool *pool,
+    CrabllmMlxLoadedModel **out_array,
+    size_t *out_count,
+    char **out_error);
+
+/*
+ * Release the array returned by crabllm_mlx_pool_list_loaded. Frees
+ * every `name` pointer and the array itself. Safe to call with
+ * array == NULL and count == 0.
+ */
+void crabllm_mlx_pool_loaded_free(CrabllmMlxLoadedModel *array, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlx/include/crabllm_mlx.h
+++ b/mlx/include/crabllm_mlx.h
@@ -253,8 +253,13 @@ CrabllmMlxStatus crabllm_mlx_pool_generate_stream(
     void *user_data,
     CrabllmMlxGenerateResult *result);
 
-/* Evict a single model from the pool. No-op if not loaded. */
-void crabllm_mlx_pool_evict(CrabllmMlxPool *pool, const char *model_dir_path);
+/*
+ * Evict a single model from the pool. Returns 1 if the slot was
+ * present and was evicted, 0 otherwise (slot absent, NULL args, or
+ * Swift-side error). Idempotent: calling on an absent slot is a
+ * no-op aside from the return value.
+ */
+int32_t crabllm_mlx_pool_evict(CrabllmMlxPool *pool, const char *model_dir_path);
 
 /* Evict all models and stop the idle monitor. */
 void crabllm_mlx_pool_stop_all(CrabllmMlxPool *pool);

--- a/mlx/tests/smoke.c
+++ b/mlx/tests/smoke.c
@@ -65,6 +65,15 @@ _Static_assert(offsetof(CrabllmMlxGenerateResult, completion_tokens) == 20,
 _Static_assert(offsetof(CrabllmMlxGenerateResult, error) == 24,
                "result.error must be at offset 24");
 
+_Static_assert(sizeof(CrabllmMlxLoadedModel) == 24,
+               "CrabllmMlxLoadedModel must be 24 bytes (8+8+8) on 64-bit");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, name) == 0,
+               "loaded_model.name must be at offset 0");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, memory_bytes) == 8,
+               "loaded_model.memory_bytes must be at offset 8");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, last_used_unix) == 16,
+               "loaded_model.last_used_unix must be at offset 16");
+
 /* Status constant pins. */
 _Static_assert(CRABLLM_MLX_OK == 0, "OK must be 0");
 _Static_assert(CRABLLM_MLX_ERR_INVALID_ARG == 1, "INVALID_ARG must be 1");
@@ -129,6 +138,25 @@ static int test_null_safety(void) {
     crabllm_mlx_session_free(NULL);
     crabllm_mlx_string_free(NULL);
     crabllm_mlx_result_free(NULL);
+    crabllm_mlx_pool_loaded_free(NULL, 0);
+    return 0;
+}
+
+static int test_pool_list_loaded_rejects_null_pool(void) {
+    CrabllmMlxLoadedModel *arr = (CrabllmMlxLoadedModel *)0xdeadbeef;
+    size_t count = 42;
+    char *err = NULL;
+    CrabllmMlxStatus status = crabllm_mlx_pool_list_loaded(NULL, &arr, &count, &err);
+    if (status == CRABLLM_MLX_OK) {
+        FAIL("pool_list_loaded(NULL) should have failed");
+    }
+    if (err == NULL) {
+        FAIL("pool_list_loaded(NULL) did not populate out_error");
+    }
+    if (count != 0) {
+        FAIL("pool_list_loaded(NULL) should have zeroed out_count, got %zu", count);
+    }
+    crabllm_mlx_string_free(err);
     return 0;
 }
 
@@ -137,6 +165,7 @@ int main(void) {
     if (test_session_new_rejects_empty() != 0) return 1;
     if (test_session_new_rejects_missing_dir() != 0) return 1;
     if (test_null_safety() != 0) return 1;
+    if (test_pool_list_loaded_rejects_null_pool() != 0) return 1;
     printf("smoke: ok\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Three additive, backward-compatible changes that together give a host process embedding \`crabllm-proxy\` + \`crabllm-mlx\` the minimum control plane it needs.

Closes #49. Supersedes #51 and #52 (all three phases squashed into this PR).

### 1. Public MLX model unload (\`MlxProvider::unload\` / \`unload_all\`)

Lets embedders drop a loaded MLX model from the Swift-side pool on demand instead of waiting for the idle eviction timer. Reuses the existing alias / repo-id / local-path resolution and is a no-op on uncached models. In-flight generations continue uninterrupted via Swift ARC on the \`ModelContainer\` returned from \`ensureLoaded\`; the next request after an unload reloads from disk.

### 2. Loaded-model inventory across FFI (\`MlxPool::loaded_models\`)

New \`CrabllmMlxLoadedModel\` C struct (24 bytes on 64-bit: \`name\` + \`memory_bytes\` + \`last_used_unix\`; layout pinned by \`_Static_assert\` in \`mlx/tests/smoke.c\`), paired with \`crabllm_mlx_pool_list_loaded\` and \`crabllm_mlx_pool_loaded_free\`. Rust side: \`LoadedModel\` type + \`MlxPool::loaded_models\` / \`MlxProvider::loaded_models\`.

Design notes:
- Swift writes the buffer via byte-offset stores against \`UnsafeMutableRawPointer\` (mirroring the \`CrabllmMlxGenerateResult\` pattern in \`Session.swift\`) rather than a plain Swift struct whose layout isn't language-guaranteed. \`loadedOffset*\` constants mirror the C-side offsets.
- \`bestEffortWeightBytes\` runs **outside** the actor — \`snapshot()\` returns only \`(name, lastUsedUnix)\`, and the FS scan for each model happens in the FFI wrapper. Concurrent generate / evict calls aren't serialized behind a directory enumeration.
- \`strdup\` is checked for NULL; OOM cleanly unwinds partial buffers before returning an error.
- \`memory_bytes\` is best-effort: sum of \`.safetensors\` / \`.bin\` / \`.gguf\` sizes on disk. Weights dominate MLX's unified-memory footprint, so this is a cheap stable proxy. Documented on both the C struct and the Rust \`LoadedModel\` type.

### 3. Optional \`UsageEvent\` broadcast bus on \`AppState\`

New \`usage_events: Option<broadcast::Sender<UsageEvent>>\` field emitting one event per request across chat (stream + non-stream), embeddings, images, and audio. \`None\` is a no-op — the standalone \`crabllm serve\` binary sets it to \`None\` and behavior is unchanged.

Design notes:
- \`UsageEvent\` carries: timestamp, request_id, key_name, model, provider, endpoint, tokens_in, tokens_out, duration_ms, status, and an optional \`error\` string.
- **Streaming status is wire-truthful**: on any connection that produced at least one chunk, response headers went out as 200 OK, so \`status\` is always 200 for post-headers streaming outcomes. Mid-stream failures surface via \`UsageEvent::error\` instead of a lying status code. The pre-stream retry-exhausted path (no bytes sent) reports the real upstream status.
- Streaming-path token counts stash in \`Arc<AtomicU32>\` pairs observed in the per-chunk closure and read by the stream-end terminator. \`Ordering::Relaxed\` is sound because \`StreamExt::chain\` only polls the terminator after the upstream yields \`Poll::Ready(None)\`. First-error capture uses a \`Mutex<Option<String>>\` scoped so the guard never crosses an await.
- Embedding events emit \`tokens_in = resp.usage.prompt_tokens, tokens_out = 0\`. Image / audio endpoints emit \`(0, 0)\` — the value there is the activity signal, not token accounting.

## Test plan

- [x] \`cargo check -p crabllm-mlx -p crabllm-proxy -p crabllm\`
- [x] \`cargo clippy -p crabllm-mlx -p crabllm-proxy -p crabllm\`
- [x] \`cargo test -p crabllm-proxy\`
- [x] \`make -C mlx test\` — smoke.c \`_Static_assert\` layout pins + NULL-safety tests + new NULL-pool \`list_loaded\` test
- [ ] Manual: generate once via provider, call \`loaded_models()\`, assert non-empty inventory with expected name / memory_bytes / last_used
- [ ] Manual: construct \`AppState\` with \`Some(tx)\`, subscribe, issue a request, observe the event
- [ ] Manual: load a model, \`unload\` it, load again, confirm cold-path reload