### PR TITLE
feat(proxy): optional usage event broadcast bus on AppState

### DIFF
--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -450,6 +450,7 @@ async fn run<S: Storage + 'static>(
         extensions: Arc::new(extensions),
         storage,
         key_map,
+        usage_events: None,
     };
 
     let app = crabllm_proxy::router(state, admin_routes);

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -1,4 +1,4 @@
-use crate::{AppState, auth::KeyName};
+use crate::{AppState, auth::KeyName, state::UsageEvent};
 use axum::{
     Extension, Json,
     extract::{Multipart, State},
@@ -17,10 +17,10 @@ use crabllm_provider::Deployment;
 use futures::StreamExt;
 use rand::Rng;
 use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU32, Ordering},
 };
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 fn record_duration(ctx: &RequestContext, status: &'static str) {
     metrics::histogram!("crabllm_request_duration_seconds",
@@ -59,6 +59,41 @@ fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
             "direction" => "completion",
         )
         .increment(completion as u64);
+    }
+}
+
+fn emit_usage<S: Storage, P: Provider>(
+    state: &AppState<S, P>,
+    ctx: &RequestContext,
+    endpoint: &'static str,
+    tokens_in: u32,
+    tokens_out: u32,
+    status: u16,
+    error: Option<String>,
+) {
+    let Some(tx) = state.usage_events.as_ref() else {
+        return;
+    };
+    let _ = tx.send(UsageEvent {
+        timestamp: SystemTime::now(),
+        request_id: ctx.request_id.clone(),
+        key_name: ctx.key_name.clone(),
+        model: ctx.model.clone(),
+        provider: ctx.provider.clone(),
+        endpoint,
+        tokens_in,
+        tokens_out,
+        duration_ms: ctx.started_at.elapsed().as_millis() as u64,
+        status,
+        error,
+    });
+}
+
+fn http_status_from_error(e: &crabllm_core::Error) -> u16 {
+    match e {
+        crabllm_core::Error::Provider { status, .. } => *status,
+        crabllm_core::Error::Timeout => 504,
+        _ => 500,
     }
 }
 
@@ -130,14 +165,30 @@ where
                     let extensions = state.extensions.clone();
                     let ctx = Arc::new(ctx);
                     let errored = Arc::new(AtomicBool::new(false));
+                    // Relaxed loads/stores on these atomics are sound: the
+                    // `done` stream-once only polls after the upstream
+                    // `.then` stream has yielded `Poll::Ready(None)`, which
+                    // happens-after every per-chunk future resolves. The
+                    // `.chain` combinator provides the ordering; the atomic
+                    // type is just for interior mutability across clones.
+                    let tokens_in = Arc::new(AtomicU32::new(0));
+                    let tokens_out = Arc::new(AtomicU32::new(0));
+                    let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
 
                     let ctx_done = ctx.clone();
                     let errored_done = errored.clone();
+                    let tokens_in_done = tokens_in.clone();
+                    let tokens_out_done = tokens_out.clone();
+                    let first_error_done = first_error.clone();
+                    let state_done = state.clone();
 
                     let observed = stream.then(move |result| {
                         let extensions = extensions.clone();
                         let ctx = ctx.clone();
                         let errored = errored.clone();
+                        let tokens_in = tokens_in.clone();
+                        let tokens_out = tokens_out.clone();
+                        let first_error = first_error.clone();
                         async move {
                             match &result {
                                 Ok(chunk) => {
@@ -149,6 +200,9 @@ where
                                             usage.prompt_tokens,
                                             usage.completion_tokens,
                                         );
+                                        tokens_in.store(usage.prompt_tokens, Ordering::Relaxed);
+                                        tokens_out
+                                            .store(usage.completion_tokens, Ordering::Relaxed);
                                     }
                                     for ext in extensions.iter() {
                                         ext.on_chunk(&ctx, chunk).await;
@@ -156,6 +210,12 @@ where
                                 }
                                 Err(error) => {
                                     errored.store(true, Ordering::Relaxed);
+                                    {
+                                        let mut slot = first_error.lock().unwrap();
+                                        if slot.is_none() {
+                                            *slot = Some(error.to_string());
+                                        }
+                                    }
                                     for ext in extensions.iter() {
                                         ext.on_error(&ctx, error).await;
                                     }
@@ -181,13 +241,22 @@ where
                     });
 
                     // Record duration once when the stream terminates.
+                    // The wire status is always 200 here — headers were
+                    // sent before the first chunk, so mid-stream failures
+                    // surface via UsageEvent::error, not status.
                     let done = futures::stream::once(async move {
-                        let status = if errored_done.load(Ordering::Relaxed) {
-                            "5xx"
-                        } else {
-                            "2xx"
-                        };
-                        record_duration(&ctx_done, status);
+                        let errored = errored_done.load(Ordering::Relaxed);
+                        record_duration(&ctx_done, if errored { "5xx" } else { "2xx" });
+                        let error = first_error_done.lock().unwrap().take();
+                        emit_usage(
+                            &state_done,
+                            &ctx_done,
+                            "chat.completions",
+                            tokens_in_done.load(Ordering::Relaxed),
+                            tokens_out_done.load(Ordering::Relaxed),
+                            200,
+                            error,
+                        );
                         Ok::<_, std::convert::Infallible>(Event::default().data("[DONE]"))
                     });
                     let full_stream = sse_stream.chain(done);
@@ -206,6 +275,15 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, "5xx");
+        emit_usage(
+            &state,
+            &ctx,
+            "chat.completions",
+            0,
+            0,
+            http_status_from_error(&e),
+            Some(e.to_string()),
+        );
         error_response(e)
     } else {
         // Non-streaming: check cache first.
@@ -221,10 +299,16 @@ where
         for deployment in &deployments {
             match try_chat_with_retries(deployment, &request).await {
                 Ok(resp) => {
-                    if let Some(ref usage) = resp.usage {
-                        record_tokens(&ctx, usage.prompt_tokens, usage.completion_tokens);
+                    let (pt, ct) = resp
+                        .usage
+                        .as_ref()
+                        .map(|u| (u.prompt_tokens, u.completion_tokens))
+                        .unwrap_or((0, 0));
+                    if pt > 0 || ct > 0 {
+                        record_tokens(&ctx, pt, ct);
                     }
                     record_duration(&ctx, "2xx");
+                    emit_usage(&state, &ctx, "chat.completions", pt, ct, 200, None);
                     for ext in state.extensions.iter() {
                         ext.on_response(&ctx, &request, &resp).await;
                     }
@@ -240,6 +324,15 @@ where
             ext.on_error(&ctx, &e).await;
         }
         record_duration(&ctx, error_status(&e));
+        emit_usage(
+            &state,
+            &ctx,
+            "chat.completions",
+            0,
+            0,
+            http_status_from_error(&e),
+            Some(e.to_string()),
+        );
         error_response(e)
     }
 }
@@ -300,6 +393,15 @@ where
         match try_embedding_with_retries(deployment, &request).await {
             Ok(resp) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(
+                    &state,
+                    &ctx,
+                    "embeddings",
+                    resp.usage.prompt_tokens,
+                    0,
+                    200,
+                    None,
+                );
                 return Json(resp).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -312,6 +414,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "embeddings",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -399,6 +510,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "images.generations", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -411,6 +523,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "images.generations",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -475,6 +596,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "audio.speech", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -487,6 +609,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "audio.speech",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 
@@ -601,6 +732,7 @@ where
         {
             Ok((bytes, content_type)) => {
                 record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, "audio.transcriptions", 0, 0, 200, None);
                 return ([(axum::http::header::CONTENT_TYPE, content_type)], bytes).into_response();
             }
             Err(e) => last_err = Some(e),
@@ -613,6 +745,15 @@ where
         ext.on_error(&ctx, &e).await;
     }
     record_duration(&ctx, error_status(&e));
+    emit_usage(
+        &state,
+        &ctx,
+        "audio.transcriptions",
+        0,
+        0,
+        http_status_from_error(&e),
+        Some(e.to_string()),
+    );
     error_response(e)
 }
 

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -8,7 +8,7 @@ use axum::{
 use crabllm_core::{Provider, Storage};
 
 pub use auth::KeyName;
-pub use state::AppState;
+pub use state::{AppState, UsageEvent};
 
 pub mod admin;
 pub mod auth;

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -3,7 +3,41 @@ use crabllm_provider::ProviderRegistry;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::SystemTime,
 };
+use tokio::sync::broadcast;
+
+/// Per-request event emitted after a request completes. Embedders
+/// subscribe to the [`AppState::usage_events`] broadcast channel to
+/// observe live traffic without scraping the Prometheus endpoint.
+#[derive(Debug, Clone)]
+pub struct UsageEvent {
+    pub timestamp: SystemTime,
+    pub request_id: String,
+    pub key_name: Option<String>,
+    pub model: String,
+    pub provider: String,
+    /// Logical endpoint: `"chat.completions"`, `"embeddings"`,
+    /// `"images.generations"`, `"audio.speech"`, `"audio.transcriptions"`.
+    pub endpoint: &'static str,
+    /// Prompt / input tokens. For embeddings this is the input token
+    /// count; for image / audio endpoints it's 0.
+    pub tokens_in: u32,
+    /// Completion / output tokens. 0 for endpoints that don't generate
+    /// tokens (embeddings, images, audio).
+    pub tokens_out: u32,
+    pub duration_ms: u64,
+    /// The wire HTTP status the client observed. For streaming chat
+    /// this is always 200 on any connection that produced at least
+    /// one chunk — mid-stream failures surface in [`Self::error`]
+    /// instead, since the response headers went out as 200 OK before
+    /// the stream broke.
+    pub status: u16,
+    /// `Some(msg)` if the request failed. For streaming chat this
+    /// includes the case where the stream started successfully (status
+    /// == 200) but errored mid-response.
+    pub error: Option<String>,
+}
 
 /// Shared application state passed to all handlers.
 ///
@@ -19,6 +53,12 @@ pub struct AppState<S: Storage, P: Provider> {
     /// Precomputed token → key name lookup for O(1) auth.
     /// Wrapped in RwLock to support runtime key management.
     pub key_map: Arc<RwLock<HashMap<String, String>>>,
+    /// Optional broadcast sink for per-request [`UsageEvent`]s. `None`
+    /// is a no-op — the standalone `crabllm serve` binary leaves it
+    /// unset and behavior is unchanged. Embedders that want live
+    /// traffic construct a sender, pass `Some(sender.clone())`, and
+    /// call `sender.subscribe()` to observe events.
+    pub usage_events: Option<broadcast::Sender<UsageEvent>>,
 }
 
 impl<S: Storage, P: Provider> Clone for AppState<S, P> {
@@ -29,6 +69,7 @@ impl<S: Storage, P: Provider> Clone for AppState<S, P> {
             extensions: self.extensions.clone(),
             storage: self.storage.clone(),
             key_map: self.key_map.clone(),
+            usage_events: self.usage_events.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `AppState::usage_events: Option<broadcast::Sender<UsageEvent>>` so a host process embedding \`crabllm-proxy\` can subscribe to per-request events without scraping the Prometheus endpoint. \`None\` is a no-op — the standalone \`crabllm serve\` binary sets it to \`None\` and behavior is unchanged.

Phase 3 of #49.

## Design notes

- \`UsageEvent\` carries: timestamp, request_id, key_name, model, provider, endpoint (chat.completions / embeddings / images.generations / audio.speech / audio.transcriptions), tokens_in, tokens_out, duration_ms, status, and an optional \`error\` string.
- Events are emitted once per request across all endpoints: chat (stream + non-stream), embeddings, image generation, audio speech, audio transcription. Emission lives next to the existing \`record_duration\` call site.
- **Streaming status is wire-truthful**: on any connection that produced at least one chunk, response headers went out as 200 OK before any possible failure, so \`UsageEvent::status\` is always 200 for post-headers streaming errors. Mid-stream failures surface via \`UsageEvent::error\` instead of a lying status code. The pre-stream retry-exhausted path (no bytes sent) reports the real upstream status.
- Streaming-path token counts are observed in the per-chunk closure and read in the stream-end \`done\` terminator. They're stashed in \`Arc<AtomicU32>\` pairs; \`Ordering::Relaxed\` is sound because \`StreamExt::chain\` only polls the terminator after the upstream yields \`Poll::Ready(None)\`, which happens-after every per-chunk future resolves. First-error capture uses an \`Arc<Mutex<Option<String>>>\` (scoped so the guard never crosses an await).
- Embedding events emit \`tokens_in = resp.usage.prompt_tokens, tokens_out = 0\`. Image / audio endpoints have no chat-style tokens and emit \`(0, 0)\` — the value there is the activity signal, not token accounting.
- \`broadcast::Sender::send().ok()\` — a full or dropped receiver is never a reason to block the proxy.

## Test plan

- [x] \`cargo check -p crabllm-proxy -p crabllm\`
- [x] \`cargo clippy -p crabllm-proxy -p crabllm\`
- [x] \`cargo test -p crabllm-proxy\` — existing suite still passes
- [ ] Manual: construct \`AppState\` with \`Some(tx)\`, subscribe, issue a request, assert the event arrives with expected shape