### PR TITLE
feat(mlx): expose loaded_models inventory across FFI

### DIFF
--- a/crates/mlx/src/ffi.rs
+++ b/crates/mlx/src/ffi.rs
@@ -52,6 +52,16 @@ pub struct CrabllmMlxGenerateResult {
     pub error: *mut c_char,
 }
 
+/// Layout mirror of `CrabllmMlxLoadedModel` in `crabllm_mlx.h`.
+/// `memory_bytes` is `size_t` on the C side — `usize` here keeps
+/// the ABI stable on 64-bit platforms (the only target we build).
+#[repr(C)]
+pub struct CrabllmMlxLoadedModel {
+    pub name: *const c_char,
+    pub memory_bytes: usize,
+    pub last_used_unix: i64,
+}
+
 pub type CrabllmMlxTokenFn = unsafe extern "C" fn(*const c_char, *mut c_void) -> c_int;
 
 #[allow(dead_code)] // Session-level FFI is used by tests and as an escape hatch
@@ -110,4 +120,13 @@ unsafe extern "C" {
     pub fn crabllm_mlx_pool_evict(pool: *mut CrabllmMlxPool, model_dir_path: *const c_char);
 
     pub fn crabllm_mlx_pool_stop_all(pool: *mut CrabllmMlxPool);
+
+    pub fn crabllm_mlx_pool_list_loaded(
+        pool: *mut CrabllmMlxPool,
+        out_array: *mut *mut CrabllmMlxLoadedModel,
+        out_count: *mut usize,
+        out_error: *mut *mut c_char,
+    ) -> CrabllmMlxStatus;
+
+    pub fn crabllm_mlx_pool_loaded_free(array: *mut CrabllmMlxLoadedModel, count: usize);
 }

--- a/crates/mlx/src/pool.rs
+++ b/crates/mlx/src/pool.rs
@@ -12,10 +12,23 @@ use crate::session::{
 };
 use crabllm_core::Error;
 use std::{
-    ffi::{CString, c_char},
+    ffi::{CStr, CString, c_char},
     os::raw::c_void,
     ptr,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
+
+/// One entry in [`MlxPool::loaded_models`]'s inventory. `name` is the
+/// local directory path the pool stores the slot under (what was
+/// passed to `generate`). `memory_bytes` is a best-effort weight-file
+/// footprint on disk — the weights dominate MLX's unified-memory
+/// residency, so it's a stable proxy for "how big is this slot".
+#[derive(Debug, Clone)]
+pub struct LoadedModel {
+    pub name: String,
+    pub memory_bytes: u64,
+    pub last_used: SystemTime,
+}
 
 /// Handle to a Swift-side multi-model pool.
 pub struct MlxPool {
@@ -145,6 +158,56 @@ impl MlxPool {
     /// Evict all models and stop the idle monitor.
     pub(crate) fn stop_all(&self) {
         unsafe { ffi::crabllm_mlx_pool_stop_all(self.inner.as_ptr()) };
+    }
+
+    /// Snapshot the pool's loaded-model inventory.
+    ///
+    /// Each returned [`LoadedModel`] is a copy of the Swift-side slot
+    /// at snapshot time. Concurrent generate / evict calls race
+    /// cleanly against this — the Swift actor serializes the
+    /// snapshot with every other mutation.
+    pub fn loaded_models(&self) -> Result<Vec<LoadedModel>, Error> {
+        let mut arr: *mut ffi::CrabllmMlxLoadedModel = ptr::null_mut();
+        let mut count: usize = 0;
+        let mut err: *mut c_char = ptr::null_mut();
+        let status = unsafe {
+            ffi::crabllm_mlx_pool_list_loaded(
+                self.inner.as_ptr(),
+                &mut arr,
+                &mut count,
+                &mut err,
+            )
+        };
+        if status != ffi::CRABLLM_MLX_OK {
+            let msg = unsafe { take_owned_c_string(err) };
+            return Err(translate_status(status, msg));
+        }
+
+        // Empty inventory: Swift may leave arr NULL; count == 0.
+        // Nothing to free and nothing to copy.
+        if count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut out = Vec::with_capacity(count);
+        for i in 0..count {
+            let item = unsafe { &*arr.add(i) };
+            let name = if item.name.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(item.name) }
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            let last_used = UNIX_EPOCH + Duration::from_secs(item.last_used_unix.max(0) as u64);
+            out.push(LoadedModel {
+                name,
+                memory_bytes: item.memory_bytes as u64,
+                last_used,
+            });
+        }
+        unsafe { ffi::crabllm_mlx_pool_loaded_free(arr, count) };
+        Ok(out)
     }
 }
 

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     download,
-    pool::MlxPool,
+    pool::{LoadedModel, MlxPool},
     session::{GenerateOptions, GenerateRequest},
 };
 use crabllm_core::{
@@ -41,6 +41,12 @@ impl std::fmt::Debug for MlxProvider {
 impl MlxProvider {
     pub fn new(pool: Arc<MlxPool>) -> Self {
         Self { pool }
+    }
+
+    /// Snapshot the pool's loaded-model inventory. See
+    /// [`MlxPool::loaded_models`] for the full contract.
+    pub fn loaded_models(&self) -> Result<Vec<LoadedModel>, Error> {
+        self.pool.loaded_models()
     }
 
     /// Resolve a model name to a local directory path.

--- a/mlx/Sources/CrabllmMlx/Pool.swift
+++ b/mlx/Sources/CrabllmMlx/Pool.swift
@@ -67,6 +67,17 @@ actor MlxPool {
         monitorTask = nil
     }
 
+    /// Snapshot every loaded slot's name and last-used time. Returns
+    /// the minimum the FFI wrapper needs to build a `LoadedModel`
+    /// array; memory-footprint computation is a filesystem scan and
+    /// runs *outside* the actor so it doesn't block concurrent
+    /// generate / evict calls.
+    func snapshot() -> [(name: String, lastUsedUnix: Int64)] {
+        models.map { (dir, entry) in
+            (name: dir, lastUsedUnix: Int64(entry.lastUsed.timeIntervalSince1970))
+        }
+    }
+
     private func evictExpired() {
         let now = Date()
         let expired = models.filter { now.timeIntervalSince($0.value.lastUsed) > idleTimeout }
@@ -247,4 +258,146 @@ public func crabllm_mlx_pool_stop_all(_ pool: UnsafeMutableRawPointer?) {
     guard let pool = pool else { return }
     let actor = Unmanaged<MlxPoolBox>.fromOpaque(pool).takeUnretainedValue().pool
     try? blockingAwait { await actor.stopAll() }
+}
+
+// MARK: - Loaded model inventory
+//
+// The C ABI struct `CrabllmMlxLoadedModel` is written via byte-offset
+// stores against an `UnsafeMutableRawPointer` buffer, mirroring the
+// `CrabllmMlxGenerateResult` pattern in Session.swift. We don't define
+// a Swift struct for it because plain Swift structs have no layout
+// guarantee — smoke.c pins the C-side layout, and these offset
+// constants are the Swift-side mirror pinned to those same values.
+
+private let loadedOffsetName = 0
+private let loadedOffsetMemoryBytes = 8
+private let loadedOffsetLastUsedUnix = 16
+private let loadedModelStride = 24
+
+/// Sum of weight-file sizes under a model directory. Best-effort:
+/// unreadable / missing paths contribute zero. Runs outside the actor
+/// so concurrent generate/evict aren't blocked on filesystem I/O.
+private func bestEffortWeightBytes(atPath dir: String) -> UInt64 {
+    let fm = FileManager.default
+    let url = URL(fileURLWithPath: dir)
+    guard let entries = try? fm.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: [.fileSizeKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return 0
+    }
+    var total: UInt64 = 0
+    for entry in entries {
+        let ext = entry.pathExtension.lowercased()
+        guard ext == "safetensors" || ext == "bin" || ext == "gguf" else { continue }
+        if let size = try? entry.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+            total &+= UInt64(size)
+        }
+    }
+    return total
+}
+
+/// Free all strdup'd name pointers in a loaded-model buffer, then
+/// deallocate the buffer. `count` must match the allocation.
+private func loadedBufferFreeNames(_ buf: UnsafeMutableRawPointer, _ count: Int) {
+    for i in 0..<count {
+        let slot = buf.advanced(by: i * loadedModelStride + loadedOffsetName)
+            .assumingMemoryBound(to: UnsafeMutablePointer<CChar>?.self)
+        if let name = slot.pointee {
+            free(UnsafeMutableRawPointer(name))
+            slot.pointee = nil
+        }
+    }
+}
+
+@_cdecl("crabllm_mlx_pool_list_loaded")
+public func crabllm_mlx_pool_list_loaded(
+    _ pool: UnsafeMutableRawPointer?,
+    _ outArray: UnsafeMutablePointer<UnsafeMutableRawPointer?>?,
+    _ outCount: UnsafeMutablePointer<Int>?,
+    _ outError: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?
+) -> Int32 {
+    guard let outArray = outArray, let outCount = outCount else {
+        if let outError = outError {
+            outError.pointee = cString("out_array / out_count is NULL")
+        }
+        return CRABLLM_MLX_ERR_INVALID_ARG
+    }
+    outArray.pointee = nil
+    outCount.pointee = 0
+
+    guard let pool = pool else {
+        if let outError = outError {
+            outError.pointee = cString("pool is NULL")
+        }
+        return CRABLLM_MLX_ERR_INVALID_ARG
+    }
+
+    let actor = Unmanaged<MlxPoolBox>.fromOpaque(pool).takeUnretainedValue().pool
+    let snapshot: [(name: String, lastUsedUnix: Int64)]
+    do {
+        snapshot = try blockingAwait { await actor.snapshot() }
+    } catch {
+        if let outError = outError {
+            outError.pointee = cString("pool list_loaded error: \(error)")
+        }
+        return CRABLLM_MLX_ERR_UNKNOWN
+    }
+
+    let count = snapshot.count
+    if count == 0 {
+        return CRABLLM_MLX_OK
+    }
+
+    // Compute memory footprints outside the actor — each one is a
+    // FileManager scan, and we don't want to serialize all pool
+    // operations behind a directory enumeration.
+    let memoryBytes: [UInt64] = snapshot.map { bestEffortWeightBytes(atPath: $0.name) }
+
+    // Raw-byte buffer; field layout is pinned by smoke.c's
+    // _Static_assert on the C side and the `loadedOffset*` constants
+    // on this side.
+    let buf = UnsafeMutableRawPointer.allocate(
+        byteCount: count * loadedModelStride,
+        alignment: MemoryLayout<UInt64>.alignment
+    )
+    // Zero the buffer so partial-failure cleanup sees NULL name slots.
+    buf.initializeMemory(as: UInt8.self, repeating: 0, count: count * loadedModelStride)
+
+    for (idx, entry) in snapshot.enumerated() {
+        guard let namePtr = cString(entry.name) else {
+            // strdup OOM: release any names we've already written,
+            // deallocate, and report failure.
+            loadedBufferFreeNames(buf, idx)
+            buf.deallocate()
+            if let outError = outError {
+                outError.pointee = cString("pool list_loaded: out of memory")
+            }
+            return CRABLLM_MLX_ERR_UNKNOWN
+        }
+        let base = buf.advanced(by: idx * loadedModelStride)
+        base.advanced(by: loadedOffsetName)
+            .assumingMemoryBound(to: UnsafeMutablePointer<CChar>?.self)
+            .pointee = namePtr
+        base.advanced(by: loadedOffsetMemoryBytes)
+            .assumingMemoryBound(to: UInt.self)
+            .pointee = UInt(memoryBytes[idx])
+        base.advanced(by: loadedOffsetLastUsedUnix)
+            .assumingMemoryBound(to: Int64.self)
+            .pointee = entry.lastUsedUnix
+    }
+    outArray.pointee = buf
+    outCount.pointee = count
+    return CRABLLM_MLX_OK
+}
+
+@_cdecl("crabllm_mlx_pool_loaded_free")
+public func crabllm_mlx_pool_loaded_free(
+    _ array: UnsafeMutableRawPointer?,
+    _ count: Int
+) {
+    guard let array = array else { return }
+    loadedBufferFreeNames(array, count)
+    array.deallocate()
 }

--- a/mlx/include/crabllm_mlx.h
+++ b/mlx/include/crabllm_mlx.h
@@ -259,6 +259,50 @@ void crabllm_mlx_pool_evict(CrabllmMlxPool *pool, const char *model_dir_path);
 /* Evict all models and stop the idle monitor. */
 void crabllm_mlx_pool_stop_all(CrabllmMlxPool *pool);
 
+/*
+ * One entry in the pool's loaded-model inventory. Ownership: returned
+ * by crabllm_mlx_pool_list_loaded in a caller-owned array that must
+ * be released with crabllm_mlx_pool_loaded_free. `name` is a null-
+ * terminated UTF-8 string (the local directory path the pool stores
+ * the slot under). `memory_bytes` is a best-effort resident footprint
+ * — currently the sum of weight-file sizes on disk (.safetensors /
+ * .bin / .gguf), which dominates MLX's unified-memory footprint.
+ * `last_used_unix` is seconds since the epoch of the last generate
+ * call that touched the slot.
+ *
+ * Field order is chosen to eliminate padding on 64-bit: 8, 8, 8.
+ */
+typedef struct {
+    const char *name;
+    size_t memory_bytes;
+    int64_t last_used_unix;
+} CrabllmMlxLoadedModel;
+
+/*
+ * Snapshot the pool's loaded-model inventory.
+ *
+ * On success, `*out_array` points to a newly allocated array of
+ * `*out_count` `CrabllmMlxLoadedModel` entries; the caller owns the
+ * array and every `name` pointer inside it, and must release the
+ * whole thing via `crabllm_mlx_pool_loaded_free`. On empty pool,
+ * `*out_count == 0` and `*out_array` may be NULL.
+ *
+ * Blocking. Call from a background thread. Actor-isolated: races
+ * cleanly against concurrent generate / evict calls.
+ */
+CrabllmMlxStatus crabllm_mlx_pool_list_loaded(
+    CrabllmMlxPool *pool,
+    CrabllmMlxLoadedModel **out_array,
+    size_t *out_count,
+    char **out_error);
+
+/*
+ * Release the array returned by crabllm_mlx_pool_list_loaded. Frees
+ * every `name` pointer and the array itself. Safe to call with
+ * array == NULL and count == 0.
+ */
+void crabllm_mlx_pool_loaded_free(CrabllmMlxLoadedModel *array, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mlx/tests/smoke.c
+++ b/mlx/tests/smoke.c
@@ -65,6 +65,15 @@ _Static_assert(offsetof(CrabllmMlxGenerateResult, completion_tokens) == 20,
 _Static_assert(offsetof(CrabllmMlxGenerateResult, error) == 24,
                "result.error must be at offset 24");
 
+_Static_assert(sizeof(CrabllmMlxLoadedModel) == 24,
+               "CrabllmMlxLoadedModel must be 24 bytes (8+8+8) on 64-bit");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, name) == 0,
+               "loaded_model.name must be at offset 0");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, memory_bytes) == 8,
+               "loaded_model.memory_bytes must be at offset 8");
+_Static_assert(offsetof(CrabllmMlxLoadedModel, last_used_unix) == 16,
+               "loaded_model.last_used_unix must be at offset 16");
+
 /* Status constant pins. */
 _Static_assert(CRABLLM_MLX_OK == 0, "OK must be 0");
 _Static_assert(CRABLLM_MLX_ERR_INVALID_ARG == 1, "INVALID_ARG must be 1");
@@ -129,6 +138,25 @@ static int test_null_safety(void) {
     crabllm_mlx_session_free(NULL);
     crabllm_mlx_string_free(NULL);
     crabllm_mlx_result_free(NULL);
+    crabllm_mlx_pool_loaded_free(NULL, 0);
+    return 0;
+}
+
+static int test_pool_list_loaded_rejects_null_pool(void) {
+    CrabllmMlxLoadedModel *arr = (CrabllmMlxLoadedModel *)0xdeadbeef;
+    size_t count = 42;
+    char *err = NULL;
+    CrabllmMlxStatus status = crabllm_mlx_pool_list_loaded(NULL, &arr, &count, &err);
+    if (status == CRABLLM_MLX_OK) {
+        FAIL("pool_list_loaded(NULL) should have failed");
+    }
+    if (err == NULL) {
+        FAIL("pool_list_loaded(NULL) did not populate out_error");
+    }
+    if (count != 0) {
+        FAIL("pool_list_loaded(NULL) should have zeroed out_count, got %zu", count);
+    }
+    crabllm_mlx_string_free(err);
     return 0;
 }
 
@@ -137,6 +165,7 @@ int main(void) {
     if (test_session_new_rejects_empty() != 0) return 1;
     if (test_session_new_rejects_missing_dir() != 0) return 1;
     if (test_null_safety() != 0) return 1;
+    if (test_pool_list_loaded_rejects_null_pool() != 0) return 1;
     printf("smoke: ok\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds \`MlxPool::loaded_models()\` + an \`MlxProvider::loaded_models()\` pass-through that snapshots the Swift pool's slot table across the C ABI. Each entry carries the slot key (local directory path), a best-effort weight-file footprint on disk, and the last-used unix timestamp. Answers "what's loaded, how big, how fresh?" without instrumentation side-channels.

Phase 2 of #49.

## Design notes

### C ABI (\`mlx/include/crabllm_mlx.h\`)

New 24-byte struct (8+8+8, no padding on 64-bit):

\`\`\`c
typedef struct {
    const char *name;
    size_t memory_bytes;
    int64_t last_used_unix;
} CrabllmMlxLoadedModel;
\`\`\`

Plus \`crabllm_mlx_pool_list_loaded(pool, out_array, out_count, out_error)\` returning a caller-owned array, paired with \`crabllm_mlx_pool_loaded_free(array, count)\`. Layout is pinned via \`_Static_assert\` in \`mlx/tests/smoke.c\`.

### Swift side (\`Pool.swift\`)

- \`MlxPool.snapshot()\` returns \`[(name, lastUsedUnix)]\` — only the minimum the actor has to serialize. \`bestEffortWeightBytes\` (sum of \`.safetensors\` / \`.bin\` / \`.gguf\` sizes) runs **outside** the actor in the FFI wrapper so concurrent \`generate\` / \`evict\` calls aren't stalled behind a filesystem scan.
- The loaded-model buffer is written via byte-offset stores against \`UnsafeMutableRawPointer\` (\`loadedOffsetName\` = 0, \`loadedOffsetMemoryBytes\` = 8, \`loadedOffsetLastUsedUnix\` = 16, stride = 24), mirroring the \`CrabllmMlxGenerateResult\` pattern in \`Session.swift\`. A plain Swift struct has no layout guarantee; offset-based writes make both sides pinnable by \`smoke.c\`.
- \`strdup\` is checked for NULL — on allocation failure, partial buffers unwind cleanly (every already-written \`name\` is freed, buffer is deallocated, OOM error is reported).
- Empty-pool path returns \`CRABLLM_MLX_OK\` with \`out_array = NULL\`, \`out_count = 0\` without allocating anything — no leak.

### Rust side

- \`LoadedModel { name: String, memory_bytes: u64, last_used: SystemTime }\` in \`crates/mlx/src/pool.rs\`.
- \`MlxPool::loaded_models()\` handles NULL-array + count==0 as "empty pool" (early return) and deep-copies name strings via \`CStr\` before calling \`pool_loaded_free\`.
- \`MlxProvider::loaded_models()\` is a one-line pass-through.

### Memory-bytes semantics

\`memory_bytes\` is a **best-effort** proxy — disk-side sum of weight files, not true unified-memory RSS. MLX doesn't expose per-model allocator stats and chasing true residency wasn't worth the v1 shipping cost. Weights dominate MLX's memory footprint so this is a stable, cheap metric. Documented on both the C struct and the Rust \`LoadedModel\` type.

## Test plan

- [x] \`make -C mlx test\` — smoke.c \`_Static_assert\` pins + NULL-safety tests (includes new NULL-pool list_loaded test)
- [x] \`cargo check -p crabllm-mlx\`
- [x] \`cargo clippy -p crabllm-mlx\`
- [ ] Manual: generate once, call \`provider.loaded_models()\`, assert \`len == 1\`, name matches the resolved dir, \`memory_bytes > 0\`, \`last_used\` is recent