### PR TITLE
feat(proxy): anthropic-compatible /v1/messages endpoint

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,11 +7,13 @@ pub use extension::{Extension, ExtensionError, RequestContext};
 pub use provider::{BoxStream, Provider};
 pub use storage::{BoxFuture, KvPairs, PREFIX_LEN, Prefix, Storage, storage_key};
 pub use types::{
-    AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice,
-    ChunkChoice, CompletionTokensDetails, Delta, Embedding, EmbeddingInput, EmbeddingRequest,
-    EmbeddingResponse, EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef,
-    ImageRequest, Message, Model, ModelList, MultipartField, Role, Stop, Tool, ToolCall,
-    ToolCallDelta, ToolChoice, ToolType, Usage,
+    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
+    AnthropicSystem, AnthropicTool, AnthropicUsage, AudioSpeechRequest, ChatCompletionChunk,
+    ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, CompletionTokensDetails,
+    DEFAULT_MAX_TOKENS, Delta, Embedding, EmbeddingInput, EmbeddingRequest, EmbeddingResponse,
+    EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef, ImageRequest,
+    Message, Model, ModelList, MultipartField, Role, Stop, ThinkingConfig, Tool, ToolCall,
+    ToolCallDelta, ToolChoice, ToolResultContent, ToolType, Usage,
 };
 
 mod config;

--- a/crates/core/src/types/anthropic.rs
+++ b/crates/core/src/types/anthropic.rs
@@ -1,0 +1,144 @@
+//! Anthropic Messages API wire types.
+//!
+//! These types are bidirectional — used both when crabllm acts as a client of
+//! the upstream Anthropic API (outbound, in the `provider` crate) and when
+//! crabllm exposes an Anthropic-compatible endpoint to its own clients
+//! (inbound, in the `proxy` crate).
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThinkingConfig {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub budget_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicRequest {
+    pub model: String,
+    pub messages: Vec<AnthropicMessage>,
+    pub max_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<AnthropicSystem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<AnthropicTool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequences: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<ThinkingConfig>,
+}
+
+/// System prompt: either a plain string or an array of content blocks.
+/// Anthropic SDK clients send either form interchangeably.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicSystem {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicMessage {
+    pub role: String,
+    pub content: AnthropicContent,
+}
+
+/// Message content: either a plain string or an array of content blocks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AnthropicContent {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+/// A content block. Used in both requests and responses, so the variant set is
+/// the union of what either side can send; producers only emit valid variants
+/// for their direction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AnthropicContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { source: serde_json::Value },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: ToolResultContent,
+    },
+    #[serde(rename = "thinking")]
+    Thinking {
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        thinking: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+}
+
+/// Tool result content: Anthropic allows either a plain string or an array of
+/// text/image blocks nested inside the result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolResultContent {
+    Text(String),
+    Blocks(Vec<AnthropicContentBlock>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicTool {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicResponse {
+    pub id: String,
+    #[serde(default = "default_message_type")]
+    pub r#type: String,
+    #[serde(default = "default_assistant_role")]
+    pub role: String,
+    pub model: String,
+    pub content: Vec<AnthropicContentBlock>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+    pub usage: AnthropicUsage,
+}
+
+fn default_message_type() -> String {
+    "message".to_string()
+}
+
+fn default_assistant_role() -> String {
+    "assistant".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnthropicUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_input_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_input_tokens: Option<u32>,
+}

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -1,3 +1,8 @@
+pub use anthropic::{
+    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
+    AnthropicSystem, AnthropicTool, AnthropicUsage, DEFAULT_MAX_TOKENS, ThinkingConfig,
+    ToolResultContent,
+};
 pub use audio::AudioSpeechRequest;
 pub use chat::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice,
@@ -11,6 +16,7 @@ pub use image::ImageRequest;
 pub use model::{Model, ModelList};
 pub use multipart::MultipartField;
 
+mod anthropic;
 mod audio;
 mod chat;
 mod embedding;

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -1,132 +1,23 @@
 use crate::provider::schema;
 use bytes::{Buf, BytesMut};
 use crabllm_core::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, Delta,
-    Error, FinishReason, FunctionCall, FunctionCallDelta, Message, Role, Stop, ToolCall,
-    ToolCallDelta, ToolChoice, ToolType, Usage,
+    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
+    AnthropicSystem, AnthropicTool, AnthropicUsage, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, Choice, ChunkChoice, DEFAULT_MAX_TOKENS, Delta, Error, FinishReason,
+    FunctionCall, FunctionCallDelta, Message, Role, Stop, ThinkingConfig, ToolCall, ToolCallDelta,
+    ToolChoice, ToolResultContent, ToolType, Usage,
 };
 use futures::{
     TryStreamExt, pin_mut,
     stream::{self, Stream},
 };
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
-const DEFAULT_MAX_TOKENS: u32 = 4096;
 const BASE_URL: &str = "https://api.anthropic.com/v1";
 const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
 const OAUTH_BETA: &str = "oauth-2025-04-20";
 
-// ── Anthropic-native request types ──
-
-#[derive(Serialize)]
-struct ThinkingConfig {
-    #[serde(rename = "type")]
-    kind: String,
-    budget_tokens: u32,
-}
-
-#[derive(Serialize)]
-struct AnthropicRequest {
-    model: String,
-    messages: Vec<AnthropicMessage>,
-    max_tokens: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    stream: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<Vec<AnthropicTool>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tool_choice: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    stop_sequences: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    thinking: Option<ThinkingConfig>,
-}
-
-#[derive(Serialize)]
-struct AnthropicMessage {
-    role: String,
-    content: AnthropicContent,
-}
-
-/// Message content: either a plain string or an array of content blocks.
-#[derive(Serialize)]
-#[serde(untagged)]
-enum AnthropicContent {
-    Text(String),
-    Blocks(Vec<AnthropicContentBlock>),
-}
-
-/// A content block in a message (text, image, tool_use, or tool_result).
-#[derive(Serialize)]
-#[serde(tag = "type")]
-enum AnthropicContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "image")]
-    Image { source: serde_json::Value },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: serde_json::Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: String,
-        content: String,
-    },
-}
-
-#[derive(Serialize)]
-struct AnthropicTool {
-    name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    input_schema: serde_json::Value,
-}
-
-// ── Anthropic-native response types ──
-
-#[derive(Deserialize)]
-struct AnthropicResponse {
-    id: String,
-    model: String,
-    content: Vec<ResponseContentBlock>,
-    stop_reason: Option<String>,
-    usage: AnthropicUsage,
-}
-
-#[derive(Deserialize)]
-struct ResponseContentBlock {
-    #[serde(rename = "type")]
-    kind: String,
-    #[serde(default)]
-    text: String,
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
-    input: Option<serde_json::Value>,
-}
-
-#[derive(Deserialize)]
-struct AnthropicUsage {
-    input_tokens: u32,
-    output_tokens: u32,
-    #[serde(default)]
-    cache_read_input_tokens: Option<u32>,
-    #[serde(default)]
-    cache_creation_input_tokens: Option<u32>,
-}
-
-// ── Anthropic SSE event types ──
+// ── Anthropic SSE event types (parse-only) ──
 
 #[derive(Deserialize)]
 struct SseEvent {
@@ -216,7 +107,7 @@ fn translate_request(request: &ChatCompletionRequest) -> AnthropicRequest {
                 role: "user".to_string(),
                 content: AnthropicContent::Blocks(vec![AnthropicContentBlock::ToolResult {
                     tool_use_id,
-                    content: content_str,
+                    content: ToolResultContent::Text(content_str),
                 }]),
             });
         } else if msg.role == Role::Assistant
@@ -310,7 +201,7 @@ fn translate_request(request: &ChatCompletionRequest) -> AnthropicRequest {
     let system = if system_parts.is_empty() {
         None
     } else {
-        Some(system_parts.join("\n"))
+        Some(AnthropicSystem::Text(system_parts.join("\n")))
     };
 
     // B2: When tool_choice is "none", omit tools and tool_choice entirely.
@@ -418,29 +309,27 @@ fn translate_response(resp: AnthropicResponse) -> ChatCompletionResponse {
     let mut tool_calls = Vec::new();
     let mut reasoning_content = None;
 
-    for block in &resp.content {
-        match block.kind.as_str() {
-            "thinking" => {
-                if !block.text.is_empty() {
-                    reasoning_content = Some(block.text.clone());
+    for block in resp.content {
+        match block {
+            AnthropicContentBlock::Text { text } => content_text.push_str(&text),
+            AnthropicContentBlock::Thinking { thinking, .. } => {
+                if !thinking.is_empty() {
+                    reasoning_content = Some(thinking);
                 }
             }
-            "text" => content_text.push_str(&block.text),
-            "tool_use" => {
-                if let (Some(id), Some(name), Some(input)) = (&block.id, &block.name, &block.input)
-                {
-                    tool_calls.push(ToolCall {
-                        index: None,
-                        id: id.clone(),
-                        kind: ToolType::Function,
-                        function: FunctionCall {
-                            name: name.clone(),
-                            arguments: serde_json::to_string(input).unwrap_or_default(),
-                        },
-                    });
-                }
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                tool_calls.push(ToolCall {
+                    index: None,
+                    id,
+                    kind: ToolType::Function,
+                    function: FunctionCall {
+                        name,
+                        arguments: serde_json::to_string(&input).unwrap_or_default(),
+                    },
+                });
             }
-            _ => {}
+            // Image and ToolResult do not appear in assistant responses.
+            AnthropicContentBlock::Image { .. } | AnthropicContentBlock::ToolResult { .. } => {}
         }
     }
 

--- a/crates/proxy/src/anthropic/handler.rs
+++ b/crates/proxy/src/anthropic/handler.rs
@@ -1,0 +1,288 @@
+//! HTTP handler for `POST /v1/messages` (Anthropic-compatible).
+//!
+//! Translates the inbound `AnthropicRequest` to the internal
+//! `ChatCompletionRequest`, dispatches via the same provider pipeline the
+//! OpenAI `/v1/chat/completions` handler uses, then translates the response
+//! (or streaming chunk sequence) back to Anthropic's wire format.
+
+use crate::{
+    AppState,
+    anthropic::{from_chat_completion, to_anthropic_sse, to_chat_completion},
+    auth::KeyName,
+    handlers::{
+        emit_usage, emit_usage_error, error_response, error_status, record_duration, record_tokens,
+        try_chat_with_retries, try_stream_with_retries,
+    },
+};
+use axum::{
+    Extension, Json,
+    extract::State,
+    http::StatusCode,
+    response::{
+        IntoResponse, Response,
+        sse::{Event, Sse},
+    },
+};
+use crabllm_core::{AnthropicRequest, ApiError, Provider, RequestContext, Storage};
+use futures::StreamExt;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU32, Ordering},
+};
+use std::time::Instant;
+
+const ENDPOINT: &str = "messages";
+
+/// POST /v1/messages
+pub async fn messages<S, P>(
+    State(state): State<AppState<S, P>>,
+    Extension(key_name): Extension<KeyName>,
+    Json(anthropic_req): Json<AnthropicRequest>,
+) -> Response
+where
+    S: Storage + 'static,
+    P: Provider + 'static,
+{
+    let mut request = to_chat_completion(anthropic_req);
+
+    let model = state.registry.resolve(&request.model).to_string();
+    let deployments = match state.registry.dispatch_list(&model) {
+        Some(list) => list,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ApiError::new(
+                    format!("model '{model}' not found"),
+                    "invalid_request_error",
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let provider_name = state
+        .registry
+        .provider_name(&model)
+        .unwrap_or_default()
+        .to_string();
+
+    let ctx = RequestContext {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        model: model.clone(),
+        provider: provider_name,
+        key_name: key_name.0,
+        is_stream: request.stream == Some(true),
+        started_at: Instant::now(),
+    };
+
+    for ext in state.extensions.iter() {
+        if let Err(ext_err) = ext.on_request(&ctx).await {
+            return (
+                StatusCode::from_u16(ext_err.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                Json(ext_err.body),
+            )
+                .into_response();
+        }
+    }
+
+    if ctx.is_stream {
+        request
+            .extra
+            .entry("stream_options".to_string())
+            .or_insert(serde_json::json!({ "include_usage": true }));
+
+        let mut last_err = None;
+        for deployment in &deployments {
+            match try_stream_with_retries(deployment, &request).await {
+                Ok(stream) => {
+                    let extensions = state.extensions.clone();
+                    let ctx = Arc::new(ctx);
+                    let errored = Arc::new(AtomicBool::new(false));
+                    let tokens_in = Arc::new(AtomicU32::new(0));
+                    let tokens_out = Arc::new(AtomicU32::new(0));
+                    let first_error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+                    let ctx_done = ctx.clone();
+                    let errored_done = errored.clone();
+                    let tokens_in_done = tokens_in.clone();
+                    let tokens_out_done = tokens_out.clone();
+                    let first_error_done = first_error.clone();
+
+                    let observed = stream.then(move |result| {
+                        let extensions = extensions.clone();
+                        let ctx = ctx.clone();
+                        let errored = errored.clone();
+                        let tokens_in = tokens_in.clone();
+                        let tokens_out = tokens_out.clone();
+                        let first_error = first_error.clone();
+                        async move {
+                            match &result {
+                                Ok(chunk) => {
+                                    if let Some(ref usage) = chunk.usage {
+                                        record_tokens(
+                                            &ctx,
+                                            usage.prompt_tokens,
+                                            usage.completion_tokens,
+                                        );
+                                        tokens_in.store(usage.prompt_tokens, Ordering::Relaxed);
+                                        tokens_out
+                                            .store(usage.completion_tokens, Ordering::Relaxed);
+                                    }
+                                    for ext in extensions.iter() {
+                                        ext.on_chunk(&ctx, chunk).await;
+                                    }
+                                }
+                                Err(error) => {
+                                    errored.store(true, Ordering::Relaxed);
+                                    {
+                                        let mut slot = first_error.lock().unwrap();
+                                        if slot.is_none() {
+                                            *slot = Some(error.to_string());
+                                        }
+                                    }
+                                    for ext in extensions.iter() {
+                                        ext.on_error(&ctx, error).await;
+                                    }
+                                }
+                            }
+                            result
+                        }
+                    });
+
+                    let anthropic_events = to_anthropic_sse(Box::pin(observed));
+
+                    let sse_stream = anthropic_events.map(|result| match result {
+                        Ok(event) => {
+                            let name = event.event_name();
+                            let json = serde_json::to_string(&event).unwrap_or_default();
+                            Ok::<_, std::convert::Infallible>(
+                                Event::default().event(name).data(json),
+                            )
+                        }
+                        Err(e) => {
+                            // Anthropic documents `api_error` / `overloaded_error`
+                            // rather than `server_error` in the enum.
+                            let json = serde_json::to_string(&serde_json::json!({
+                                "type": "error",
+                                "error": {
+                                    "type": "api_error",
+                                    "message": e.to_string(),
+                                },
+                            }))
+                            .unwrap_or_default();
+                            Ok(Event::default().event("error").data(json))
+                        }
+                    });
+
+                    // Wrap the stream so that emit_usage/record_duration run
+                    // exactly once, when the wire stream drains — without
+                    // putting a spurious SSE frame on the wire.
+                    let finalized = futures::stream::unfold(
+                        (
+                            Box::pin(sse_stream),
+                            Some((
+                                state.clone(),
+                                ctx_done,
+                                tokens_in_done,
+                                tokens_out_done,
+                                errored_done,
+                                first_error_done,
+                            )),
+                        ),
+                        |(mut inner, mut slot)| async move {
+                            match inner.next().await {
+                                Some(item) => Some((item, (inner, slot))),
+                                None => {
+                                    if let Some((state, ctx, ti, to, er, fe)) = slot.take() {
+                                        let errored = er.load(Ordering::Relaxed);
+                                        record_duration(&ctx, if errored { "5xx" } else { "2xx" });
+                                        let error = fe.lock().unwrap().take();
+                                        let status = if errored { 0 } else { 200 };
+                                        emit_usage(
+                                            &state,
+                                            &ctx,
+                                            ENDPOINT,
+                                            ti.load(Ordering::Relaxed),
+                                            to.load(Ordering::Relaxed),
+                                            status,
+                                            error,
+                                        );
+                                    }
+                                    None
+                                }
+                            }
+                        },
+                    );
+
+                    return Sse::new(finalized)
+                        .keep_alive(axum::response::sse::KeepAlive::new())
+                        .into_response();
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+
+        let e = last_err
+            .unwrap_or_else(|| crabllm_core::Error::Internal("no providers available".into()));
+        for ext in state.extensions.iter() {
+            ext.on_error(&ctx, &e).await;
+        }
+        record_duration(&ctx, "5xx");
+        emit_usage_error(&state, &ctx, ENDPOINT, &e);
+        return error_response(e);
+    }
+
+    // Non-streaming: cache first. A cache hit whose shape can't be translated
+    // (missing usage, zero choices) falls through to live dispatch rather than
+    // erroring — the cached payload was valid for the OpenAI handler, and the
+    // translation gap is our bug, not the client's.
+    for ext in state.extensions.iter() {
+        if let Some(cached) = ext.on_cache_lookup(&request).await
+            && let Ok(resp) = from_chat_completion(cached)
+        {
+            return Json(resp).into_response();
+        }
+    }
+
+    let mut last_err = None;
+    for deployment in &deployments {
+        match try_chat_with_retries(deployment, &request).await {
+            Ok(resp) => {
+                let (pt, ct) = resp
+                    .usage
+                    .as_ref()
+                    .map(|u| (u.prompt_tokens, u.completion_tokens))
+                    .unwrap_or((0, 0));
+                if pt > 0 || ct > 0 {
+                    record_tokens(&ctx, pt, ct);
+                }
+                record_duration(&ctx, "2xx");
+                emit_usage(&state, &ctx, ENDPOINT, pt, ct, 200, None);
+                for ext in state.extensions.iter() {
+                    ext.on_response(&ctx, &request, &resp).await;
+                }
+                return match from_chat_completion(resp) {
+                    Ok(anthropic) => Json(anthropic).into_response(),
+                    Err(e) => {
+                        for ext in state.extensions.iter() {
+                            ext.on_error(&ctx, &e).await;
+                        }
+                        record_duration(&ctx, error_status(&e));
+                        emit_usage_error(&state, &ctx, ENDPOINT, &e);
+                        error_response(e)
+                    }
+                };
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    let e =
+        last_err.unwrap_or_else(|| crabllm_core::Error::Internal("no providers available".into()));
+    for ext in state.extensions.iter() {
+        ext.on_error(&ctx, &e).await;
+    }
+    record_duration(&ctx, error_status(&e));
+    emit_usage_error(&state, &ctx, ENDPOINT, &e);
+    error_response(e)
+}

--- a/crates/proxy/src/anthropic/mod.rs
+++ b/crates/proxy/src/anthropic/mod.rs
@@ -5,8 +5,10 @@
 //! so the rest of the proxy pipeline (extensions, provider dispatch) is
 //! unchanged, then translate the response back to Anthropic's wire format.
 
+pub use handler::messages;
 pub use sse::{AnthropicSseEvent, to_anthropic_sse};
 pub use translate::{from_chat_completion, to_chat_completion};
 
+mod handler;
 mod sse;
 mod translate;

--- a/crates/proxy/src/anthropic/mod.rs
+++ b/crates/proxy/src/anthropic/mod.rs
@@ -1,0 +1,10 @@
+//! Anthropic-compatible inbound endpoint.
+//!
+//! When a client sends a request in Anthropic Messages API format, these
+//! modules normalize it to the internal OpenAI-shaped `ChatCompletionRequest`
+//! so the rest of the proxy pipeline (extensions, provider dispatch) is
+//! unchanged, then translate the response back to Anthropic's wire format.
+
+pub use translate::to_chat_completion;
+
+mod translate;

--- a/crates/proxy/src/anthropic/mod.rs
+++ b/crates/proxy/src/anthropic/mod.rs
@@ -5,6 +5,8 @@
 //! so the rest of the proxy pipeline (extensions, provider dispatch) is
 //! unchanged, then translate the response back to Anthropic's wire format.
 
+pub use sse::{AnthropicSseEvent, to_anthropic_sse};
 pub use translate::{from_chat_completion, to_chat_completion};
 
+mod sse;
 mod translate;

--- a/crates/proxy/src/anthropic/mod.rs
+++ b/crates/proxy/src/anthropic/mod.rs
@@ -5,6 +5,6 @@
 //! so the rest of the proxy pipeline (extensions, provider dispatch) is
 //! unchanged, then translate the response back to Anthropic's wire format.
 
-pub use translate::to_chat_completion;
+pub use translate::{from_chat_completion, to_chat_completion};
 
 mod translate;

--- a/crates/proxy/src/anthropic/sse.rs
+++ b/crates/proxy/src/anthropic/sse.rs
@@ -1,0 +1,371 @@
+//! Outbound SSE event model for Anthropic Messages streaming responses, plus
+//! a stream adapter that folds an OpenAI-shaped chunk stream into this model.
+//!
+//! Anthropic's `/v1/messages` streaming format is structured around *content
+//! blocks* (text, thinking, tool_use) with explicit open/close events. OpenAI's
+//! chunk stream is flat — deltas mention their kind but never announce block
+//! boundaries. The adapter below reconstructs block boundaries by watching
+//! which delta kind the current chunk carries and closing the previous block
+//! whenever the kind changes.
+//!
+//! # Usage accounting
+//!
+//! Anthropic's spec puts input_tokens on `message_start.usage` and output_tokens
+//! on `message_delta.usage`. We don't know the provider's token accounting
+//! until the *last* chunk arrives, so `message_start.usage` is emitted with
+//! all-zero counts and the final usage (including input_tokens) is delivered
+//! on `message_delta.usage`. Both the Python and TypeScript Anthropic SDKs
+//! sum these two into a final `Usage`, so the totals are correct.
+
+use crabllm_core::{
+    AnthropicContentBlock, AnthropicResponse, AnthropicUsage, ChatCompletionChunk, Error, Usage,
+};
+use futures::{Stream, StreamExt, stream};
+use serde::Serialize;
+use std::collections::VecDeque;
+
+// ── Emission event types ──
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum AnthropicSseEvent {
+    #[serde(rename = "message_start")]
+    MessageStart { message: AnthropicResponse },
+    #[serde(rename = "content_block_start")]
+    ContentBlockStart {
+        index: u32,
+        content_block: AnthropicContentBlock,
+    },
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta { index: u32, delta: BlockDelta },
+    #[serde(rename = "content_block_stop")]
+    ContentBlockStop { index: u32 },
+    #[serde(rename = "message_delta")]
+    MessageDelta {
+        delta: MessageDeltaPayload,
+        usage: AnthropicUsage,
+    },
+    #[serde(rename = "message_stop")]
+    MessageStop,
+}
+
+impl AnthropicSseEvent {
+    pub fn event_name(&self) -> &'static str {
+        match self {
+            Self::MessageStart { .. } => "message_start",
+            Self::ContentBlockStart { .. } => "content_block_start",
+            Self::ContentBlockDelta { .. } => "content_block_delta",
+            Self::ContentBlockStop { .. } => "content_block_stop",
+            Self::MessageDelta { .. } => "message_delta",
+            Self::MessageStop => "message_stop",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum BlockDelta {
+    #[serde(rename = "text_delta")]
+    Text { text: String },
+    #[serde(rename = "thinking_delta")]
+    Thinking { thinking: String },
+    #[serde(rename = "input_json_delta")]
+    InputJson { partial_json: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MessageDeltaPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequence: Option<String>,
+}
+
+// ── Adapter ──
+
+/// Fold an internal chunk stream into Anthropic SSE events.
+pub fn to_anthropic_sse(
+    chunks: impl Stream<Item = Result<ChatCompletionChunk, Error>> + Unpin + Send + 'static,
+) -> impl Stream<Item = Result<AnthropicSseEvent, Error>> + Send + 'static {
+    let state = AdapterState::default();
+    stream::unfold((chunks, state), |(mut chunks, mut state)| async move {
+        loop {
+            if let Some(event) = state.pending.pop_front() {
+                return Some((Ok(event), (chunks, state)));
+            }
+            if let Some(err) = state.deferred_error.take() {
+                state.finished = true;
+                return Some((Err(err), (chunks, state)));
+            }
+            if state.finished {
+                return None;
+            }
+            match chunks.next().await {
+                Some(Ok(chunk)) => state.handle_chunk(chunk),
+                Some(Err(e)) => state.abort_with_error(e),
+                None => state.finalize("end_turn".to_string()),
+            }
+        }
+    })
+}
+
+#[derive(Default)]
+struct AdapterState {
+    started: bool,
+    finished: bool,
+    current: Option<CurrentBlock>,
+    next_index: u32,
+    pending: VecDeque<AnthropicSseEvent>,
+    deferred_error: Option<Error>,
+    latest_usage: Option<Usage>,
+    stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CurrentBlock {
+    Text { index: u32 },
+    Thinking { index: u32 },
+    ToolUse { index: u32, openai_index: u32 },
+}
+
+impl AdapterState {
+    fn handle_chunk(&mut self, chunk: ChatCompletionChunk) {
+        self.ensure_started(&chunk);
+
+        if let Some(usage) = chunk.usage {
+            self.latest_usage = Some(usage);
+        }
+
+        let Some(choice) = chunk.choices.into_iter().next() else {
+            return;
+        };
+        let delta = choice.delta;
+
+        if let Some(reasoning) = delta.reasoning_content
+            && !reasoning.is_empty()
+        {
+            let index = self.switch_to_thinking();
+            self.pending
+                .push_back(AnthropicSseEvent::ContentBlockDelta {
+                    index,
+                    delta: BlockDelta::Thinking {
+                        thinking: reasoning,
+                    },
+                });
+        }
+
+        if let Some(text) = delta.content
+            && !text.is_empty()
+        {
+            let index = self.switch_to_text();
+            self.pending
+                .push_back(AnthropicSseEvent::ContentBlockDelta {
+                    index,
+                    delta: BlockDelta::Text { text },
+                });
+        }
+
+        if let Some(tool_deltas) = delta.tool_calls {
+            for tc in tool_deltas {
+                self.handle_tool_delta(tc);
+            }
+        }
+
+        if let Some(reason) = choice.finish_reason {
+            self.stop_reason = Some(finish_reason_to_stop(&reason));
+        }
+    }
+
+    fn ensure_started(&mut self, chunk: &ChatCompletionChunk) {
+        if self.started {
+            return;
+        }
+        self.started = true;
+        let msg = AnthropicResponse {
+            id: chunk.id.clone(),
+            r#type: "message".to_string(),
+            role: "assistant".to_string(),
+            model: chunk.model.clone(),
+            content: Vec::new(),
+            stop_reason: None,
+            stop_sequence: None,
+            usage: empty_usage(),
+        };
+        self.pending
+            .push_back(AnthropicSseEvent::MessageStart { message: msg });
+    }
+
+    fn close_current(&mut self) {
+        if let Some(block) = self.current.take() {
+            let index = match block {
+                CurrentBlock::Text { index }
+                | CurrentBlock::Thinking { index }
+                | CurrentBlock::ToolUse { index, .. } => index,
+            };
+            self.pending
+                .push_back(AnthropicSseEvent::ContentBlockStop { index });
+        }
+    }
+
+    fn switch_to_text(&mut self) -> u32 {
+        if let Some(CurrentBlock::Text { index }) = self.current {
+            return index;
+        }
+        self.close_current();
+        let index = self.allocate_index();
+        self.pending
+            .push_back(AnthropicSseEvent::ContentBlockStart {
+                index,
+                content_block: AnthropicContentBlock::Text {
+                    text: String::new(),
+                },
+            });
+        self.current = Some(CurrentBlock::Text { index });
+        index
+    }
+
+    fn switch_to_thinking(&mut self) -> u32 {
+        if let Some(CurrentBlock::Thinking { index }) = self.current {
+            return index;
+        }
+        self.close_current();
+        let index = self.allocate_index();
+        self.pending
+            .push_back(AnthropicSseEvent::ContentBlockStart {
+                index,
+                content_block: AnthropicContentBlock::Thinking {
+                    thinking: String::new(),
+                    signature: None,
+                },
+            });
+        self.current = Some(CurrentBlock::Thinking { index });
+        index
+    }
+
+    /// Open a fresh tool_use block. Always allocates a new Anthropic block
+    /// index — we never reopen a closed block. Providers that stream each
+    /// tool call contiguously (the common case) get the expected shape; a
+    /// provider that interleaved deltas across tool indices would produce a
+    /// valid but weird stream where the same tool spans multiple blocks.
+    fn open_tool_use(&mut self, openai_index: u32, id: String, name: String) -> u32 {
+        self.close_current();
+        let index = self.allocate_index();
+        self.pending
+            .push_back(AnthropicSseEvent::ContentBlockStart {
+                index,
+                content_block: AnthropicContentBlock::ToolUse {
+                    id,
+                    name,
+                    input: serde_json::json!({}),
+                },
+            });
+        self.current = Some(CurrentBlock::ToolUse {
+            index,
+            openai_index,
+        });
+        index
+    }
+
+    fn handle_tool_delta(&mut self, tc: crabllm_core::ToolCallDelta) {
+        let openai_index = tc.index;
+        let current_index = match self.current {
+            Some(CurrentBlock::ToolUse {
+                index,
+                openai_index: oi,
+            }) if oi == openai_index => index,
+            _ => {
+                let id = tc.id.clone().unwrap_or_default();
+                let name = tc
+                    .function
+                    .as_ref()
+                    .and_then(|f| f.name.clone())
+                    .unwrap_or_default();
+                self.open_tool_use(openai_index, id, name)
+            }
+        };
+
+        if let Some(func) = tc.function
+            && let Some(args) = func.arguments
+            && !args.is_empty()
+        {
+            self.pending
+                .push_back(AnthropicSseEvent::ContentBlockDelta {
+                    index: current_index,
+                    delta: BlockDelta::InputJson { partial_json: args },
+                });
+        }
+    }
+
+    fn allocate_index(&mut self) -> u32 {
+        let idx = self.next_index;
+        self.next_index += 1;
+        idx
+    }
+
+    /// Normal end-of-stream: close current block, emit message_delta/stop.
+    fn finalize(&mut self, default_stop: String) {
+        debug_assert!(
+            self.started,
+            "finalize called before any chunk arrived — caller should have produced at least one chunk"
+        );
+        self.close_current();
+        let stop_reason = self.stop_reason.take().or(Some(default_stop));
+        let usage = self
+            .latest_usage
+            .take()
+            .map(usage_to_anthropic)
+            .unwrap_or_else(empty_usage);
+        self.pending.push_back(AnthropicSseEvent::MessageDelta {
+            delta: MessageDeltaPayload {
+                stop_reason,
+                stop_sequence: None,
+            },
+            usage,
+        });
+        self.pending.push_back(AnthropicSseEvent::MessageStop);
+        self.finished = true;
+    }
+
+    /// Upstream error: flush a well-formed terminator *before* the error so
+    /// SDK clients see message_stop and release their connection instead of
+    /// hanging on a silently-aborted stream.
+    fn abort_with_error(&mut self, err: Error) {
+        if self.started {
+            self.finalize("error".to_string());
+        } else {
+            // Haven't sent message_start yet — nothing to terminate. The
+            // handler will convert the deferred error to an HTTP error.
+            self.finished = true;
+        }
+        self.deferred_error = Some(err);
+    }
+}
+
+fn empty_usage() -> AnthropicUsage {
+    AnthropicUsage {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: None,
+        cache_creation_input_tokens: None,
+    }
+}
+
+fn usage_to_anthropic(u: Usage) -> AnthropicUsage {
+    AnthropicUsage {
+        input_tokens: u.prompt_tokens,
+        output_tokens: u.completion_tokens,
+        cache_read_input_tokens: u.prompt_cache_hit_tokens,
+        cache_creation_input_tokens: u.prompt_cache_miss_tokens,
+    }
+}
+
+fn finish_reason_to_stop(reason: &crabllm_core::FinishReason) -> String {
+    use crabllm_core::FinishReason::*;
+    match reason {
+        Stop => "end_turn".to_string(),
+        Length => "max_tokens".to_string(),
+        ToolCalls => "tool_use".to_string(),
+        ContentFilter => "content_filter".to_string(),
+        Custom(s) => s.clone(),
+    }
+}

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -1,0 +1,292 @@
+//! Translate Anthropic Messages API requests into the internal
+//! `ChatCompletionRequest` shape.
+//!
+//! # Known lossiness
+//!
+//! Fields we deliberately do not preserve yet:
+//! - `cache_control` markers on blocks (prompt caching opt-in).
+//! - `metadata.user_id` and other top-level `metadata` fields.
+//! - Thinking block `signature` (only load-bearing when replaying extended
+//!   thinking back to the Anthropic upstream, which the inbound path does not
+//!   do — our providers receive OpenAI-shaped reasoning_content).
+//! - Non-text content inside `system` blocks (images get dropped).
+//! - Non-text content inside `tool_result.content` when sent as blocks.
+//! - `disable_parallel_tool_use` on `tool_choice`.
+
+use crabllm_core::{
+    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicSystem,
+    AnthropicTool, ChatCompletionRequest, FunctionCall, FunctionDef, Message, Role, Stop, Tool,
+    ToolCall, ToolChoice, ToolResultContent, ToolType,
+};
+
+pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
+    let mut messages = Vec::new();
+
+    if let Some(system) = req.system {
+        let text = match system {
+            AnthropicSystem::Text(s) => s,
+            AnthropicSystem::Blocks(blocks) => flatten_text_blocks(&blocks),
+        };
+        if !text.is_empty() {
+            messages.push(Message::system(text));
+        }
+    }
+
+    for msg in req.messages {
+        append_message(&mut messages, msg);
+    }
+
+    let stop = req.stop_sequences.map(|mut seqs| {
+        if seqs.len() == 1 {
+            Stop::Single(seqs.pop().unwrap())
+        } else {
+            Stop::Multiple(seqs)
+        }
+    });
+
+    let tools = req
+        .tools
+        .map(|tools| tools.into_iter().map(convert_tool).collect());
+    let tool_choice = req.tool_choice.as_ref().and_then(translate_tool_choice);
+
+    let mut extra = serde_json::Map::new();
+    if let Some(thinking) = req.thinking {
+        extra.insert(
+            "thinking".to_string(),
+            serde_json::json!({
+                "type": thinking.kind,
+                "budget_tokens": thinking.budget_tokens,
+            }),
+        );
+    }
+
+    ChatCompletionRequest {
+        model: req.model,
+        messages,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        max_tokens: Some(req.max_tokens),
+        stream: req.stream,
+        stop,
+        tools,
+        tool_choice,
+        frequency_penalty: None,
+        presence_penalty: None,
+        seed: None,
+        user: None,
+        reasoning_effort: None,
+        extra,
+    }
+}
+
+fn append_message(out: &mut Vec<Message>, msg: AnthropicMessage) {
+    let is_assistant = msg.role == "assistant";
+
+    let blocks = match msg.content {
+        AnthropicContent::Text(s) => {
+            out.push(if is_assistant {
+                Message::assistant(s)
+            } else {
+                Message::user(s)
+            });
+            return;
+        }
+        AnthropicContent::Blocks(b) => b,
+    };
+
+    if is_assistant {
+        out.push(assistant_from_blocks(blocks));
+    } else {
+        append_user_blocks(out, blocks);
+    }
+}
+
+/// Collapse an assistant block list into a single `Message`.
+///
+/// Anthropic assistant turns may carry interleaved thinking, text, and tool_use
+/// blocks. OpenAI's format has a flat `content` string + `tool_calls` array +
+/// `reasoning_content`, so we concatenate text, collect tool_use into
+/// tool_calls, and stash any thinking into reasoning_content.
+fn assistant_from_blocks(blocks: Vec<AnthropicContentBlock>) -> Message {
+    let mut text = String::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut reasoning = String::new();
+
+    for block in blocks {
+        match block {
+            AnthropicContentBlock::Text { text: t } => text.push_str(&t),
+            AnthropicContentBlock::Thinking { thinking, .. } => reasoning.push_str(&thinking),
+            AnthropicContentBlock::ToolUse { id, name, input } => {
+                tool_calls.push(ToolCall {
+                    index: None,
+                    id,
+                    kind: ToolType::Function,
+                    function: FunctionCall {
+                        name,
+                        arguments: serde_json::to_string(&input).unwrap_or_else(|_| "{}".into()),
+                    },
+                });
+            }
+            // Image/ToolResult are not valid on assistant turns.
+            AnthropicContentBlock::Image { .. } | AnthropicContentBlock::ToolResult { .. } => {}
+        }
+    }
+
+    let content = if text.is_empty() && !tool_calls.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::String(text))
+    };
+
+    Message {
+        role: Role::Assistant,
+        content,
+        tool_calls: if tool_calls.is_empty() {
+            None
+        } else {
+            Some(tool_calls)
+        },
+        tool_call_id: None,
+        name: None,
+        reasoning_content: if reasoning.is_empty() {
+            None
+        } else {
+            Some(reasoning)
+        },
+        extra: serde_json::Map::new(),
+    }
+}
+
+/// User turns may interleave text/image content and tool_result blocks. OpenAI
+/// splits these into distinct messages: a user message for text/image parts
+/// and a tool message per tool_result. Emit in original order so tool results
+/// stay positioned correctly relative to any follow-up user text.
+fn append_user_blocks(out: &mut Vec<Message>, blocks: Vec<AnthropicContentBlock>) {
+    let mut user_parts: Vec<serde_json::Value> = Vec::new();
+
+    for block in blocks {
+        match block {
+            AnthropicContentBlock::Text { text } => {
+                user_parts.push(serde_json::json!({"type": "text", "text": text}));
+            }
+            AnthropicContentBlock::Image { source } => {
+                if let Some(url) = image_source_to_url(&source) {
+                    user_parts.push(serde_json::json!({
+                        "type": "image_url",
+                        "image_url": {"url": url},
+                    }));
+                }
+            }
+            AnthropicContentBlock::ToolResult {
+                tool_use_id,
+                content,
+            } => {
+                flush_user_parts(out, &mut user_parts);
+                out.push(Message {
+                    role: Role::Tool,
+                    content: Some(serde_json::Value::String(tool_result_text(content))),
+                    tool_calls: None,
+                    tool_call_id: Some(tool_use_id),
+                    name: None,
+                    reasoning_content: None,
+                    extra: serde_json::Map::new(),
+                });
+            }
+            // Thinking/ToolUse are not valid on user turns.
+            AnthropicContentBlock::Thinking { .. } | AnthropicContentBlock::ToolUse { .. } => {}
+        }
+    }
+
+    flush_user_parts(out, &mut user_parts);
+}
+
+fn flush_user_parts(out: &mut Vec<Message>, parts: &mut Vec<serde_json::Value>) {
+    if parts.is_empty() {
+        return;
+    }
+    // If the only part is a text part, collapse to a plain string content so
+    // the OpenAI provider sees the simpler `content: "..."` shape.
+    let content =
+        if parts.len() == 1 && parts[0].get("type").and_then(|t| t.as_str()) == Some("text") {
+            parts[0]
+                .get("text")
+                .cloned()
+                .unwrap_or(serde_json::Value::String(String::new()))
+        } else {
+            serde_json::Value::Array(std::mem::take(parts))
+        };
+    parts.clear();
+    out.push(Message {
+        role: Role::User,
+        content: Some(content),
+        tool_calls: None,
+        tool_call_id: None,
+        name: None,
+        reasoning_content: None,
+        extra: serde_json::Map::new(),
+    });
+}
+
+fn tool_result_text(content: ToolResultContent) -> String {
+    match content {
+        ToolResultContent::Text(s) => s,
+        ToolResultContent::Blocks(blocks) => flatten_text_blocks(&blocks),
+    }
+}
+
+fn flatten_text_blocks(blocks: &[AnthropicContentBlock]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        if let AnthropicContentBlock::Text { text } = block {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text);
+        }
+    }
+    out
+}
+
+fn image_source_to_url(source: &serde_json::Value) -> Option<String> {
+    let kind = source.get("type").and_then(|t| t.as_str())?;
+    match kind {
+        "base64" => {
+            let media_type = source.get("media_type").and_then(|t| t.as_str())?;
+            let data = source.get("data").and_then(|t| t.as_str())?;
+            Some(format!("data:{media_type};base64,{data}"))
+        }
+        "url" => source
+            .get("url")
+            .and_then(|u| u.as_str())
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+fn convert_tool(t: AnthropicTool) -> Tool {
+    Tool {
+        kind: ToolType::Function,
+        function: FunctionDef {
+            name: t.name,
+            description: t.description,
+            parameters: Some(t.input_schema),
+        },
+        strict: None,
+    }
+}
+
+fn translate_tool_choice(value: &serde_json::Value) -> Option<ToolChoice> {
+    let kind = value.get("type")?.as_str()?;
+    match kind {
+        "auto" => Some(ToolChoice::Auto),
+        "any" => Some(ToolChoice::Required),
+        "tool" => value
+            .get("name")
+            .and_then(|n| n.as_str())
+            .map(|name| ToolChoice::Function {
+                name: name.to_string(),
+            }),
+        "none" => Some(ToolChoice::Disabled),
+        _ => None,
+    }
+}

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -14,9 +14,10 @@
 //! - `disable_parallel_tool_use` on `tool_choice`.
 
 use crabllm_core::{
-    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicSystem,
-    AnthropicTool, ChatCompletionRequest, FunctionCall, FunctionDef, Message, Role, Stop, Tool,
-    ToolCall, ToolChoice, ToolResultContent, ToolType,
+    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
+    AnthropicSystem, AnthropicTool, AnthropicUsage, ChatCompletionRequest, ChatCompletionResponse,
+    Error, FinishReason, FunctionCall, FunctionDef, Message, Role, Stop, Tool, ToolCall,
+    ToolChoice, ToolResultContent, ToolType, Usage,
 };
 
 pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
@@ -288,5 +289,100 @@ fn translate_tool_choice(value: &serde_json::Value) -> Option<ToolChoice> {
             }),
         "none" => Some(ToolChoice::Disabled),
         _ => None,
+    }
+}
+
+/// Translate an internal `ChatCompletionResponse` back to the Anthropic
+/// Messages API response wire shape.
+///
+/// Errors when the response has zero choices or missing usage — both indicate
+/// a provider bug or transport failure, and papering over them with empty
+/// defaults would corrupt billing and hide real problems.
+pub fn from_chat_completion(resp: ChatCompletionResponse) -> Result<AnthropicResponse, Error> {
+    let choice = resp
+        .choices
+        .into_iter()
+        .next()
+        .ok_or_else(|| Error::Internal("provider returned zero choices".into()))?;
+    let usage = resp
+        .usage
+        .ok_or_else(|| Error::Internal("provider returned no usage".into()))?;
+
+    let stop_reason = choice.finish_reason.as_ref().map(finish_reason_to_stop);
+    let content = message_to_blocks(choice.message);
+
+    Ok(AnthropicResponse {
+        id: resp.id,
+        r#type: "message".to_string(),
+        role: "assistant".to_string(),
+        model: resp.model,
+        content,
+        stop_reason,
+        stop_sequence: None,
+        usage: usage_to_anthropic(usage),
+    })
+}
+
+fn message_to_blocks(msg: Message) -> Vec<AnthropicContentBlock> {
+    let mut blocks = Vec::new();
+
+    if let Some(reasoning) = msg.reasoning_content
+        && !reasoning.is_empty()
+    {
+        blocks.push(AnthropicContentBlock::Thinking {
+            thinking: reasoning,
+            signature: None,
+        });
+    }
+
+    if let Some(text) = msg.content.as_ref().and_then(|v| v.as_str())
+        && !text.is_empty()
+    {
+        blocks.push(AnthropicContentBlock::Text {
+            text: text.to_string(),
+        });
+    }
+
+    if let Some(tool_calls) = msg.tool_calls {
+        for tc in tool_calls {
+            let input = serde_json::from_str(&tc.function.arguments)
+                .unwrap_or(serde_json::Value::Object(Default::default()));
+            blocks.push(AnthropicContentBlock::ToolUse {
+                id: tc.id,
+                name: tc.function.name,
+                input,
+            });
+        }
+    }
+
+    // Anthropic responses always carry at least one block; emit an empty text
+    // block rather than a bare empty array so SDKs don't choke.
+    if blocks.is_empty() {
+        blocks.push(AnthropicContentBlock::Text {
+            text: String::new(),
+        });
+    }
+
+    blocks
+}
+
+fn finish_reason_to_stop(reason: &FinishReason) -> String {
+    match reason {
+        FinishReason::Stop => "end_turn".to_string(),
+        FinishReason::Length => "max_tokens".to_string(),
+        FinishReason::ToolCalls => "tool_use".to_string(),
+        // Not a documented Anthropic value, but honesty beats papering over a
+        // safety event. SDKs treat unknown stop_reason as a plain string.
+        FinishReason::ContentFilter => "content_filter".to_string(),
+        FinishReason::Custom(s) => s.clone(),
+    }
+}
+
+fn usage_to_anthropic(u: Usage) -> AnthropicUsage {
+    AnthropicUsage {
+        input_tokens: u.prompt_tokens,
+        output_tokens: u.completion_tokens,
+        cache_read_input_tokens: u.prompt_cache_hit_tokens,
+        cache_creation_input_tokens: u.prompt_cache_miss_tokens,
     }
 }

--- a/crates/proxy/src/auth.rs
+++ b/crates/proxy/src/auth.rs
@@ -32,18 +32,22 @@ pub async fn auth<S: Storage + 'static, P: Provider + 'static>(
         return next.run(request).await;
     }
 
-    let auth_header = request
-        .headers()
+    // Accept either OpenAI-style `Authorization: Bearer <key>` or Anthropic-style
+    // `x-api-key: <key>`. Both map to the same virtual-key lookup.
+    let headers = request.headers();
+    let bearer = headers
         .get("authorization")
-        .and_then(|v| v.to_str().ok());
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
+    let x_api_key = headers.get("x-api-key").and_then(|v| v.to_str().ok());
 
-    let token = match auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
+    let token = match bearer.or(x_api_key) {
         Some(t) => t,
         None => {
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(ApiError::new(
-                    "missing or invalid Authorization header",
+                    "missing Authorization or x-api-key header",
                     "authentication_error",
                 )),
             )

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -2,7 +2,7 @@ use crate::{AppState, auth::KeyName, state::UsageEvent};
 use axum::{
     Extension, Json,
     extract::{Multipart, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{
         IntoResponse, Response,
         sse::{Event, Sse},
@@ -22,7 +22,7 @@ use std::sync::{
 };
 use std::time::{Duration, Instant, SystemTime};
 
-fn record_duration(ctx: &RequestContext, status: &'static str) {
+pub(crate) fn record_duration(ctx: &RequestContext, status: &'static str) {
     metrics::histogram!("crabllm_request_duration_seconds",
         "provider" => ctx.provider.clone(),
         "model" => ctx.model.clone(),
@@ -32,7 +32,7 @@ fn record_duration(ctx: &RequestContext, status: &'static str) {
     .record(ctx.started_at.elapsed().as_secs_f64());
 }
 
-fn error_status(e: &crabllm_core::Error) -> &'static str {
+pub(crate) fn error_status(e: &crabllm_core::Error) -> &'static str {
     match e {
         crabllm_core::Error::Provider { status, .. } => match status {
             429 => "429",
@@ -43,7 +43,7 @@ fn error_status(e: &crabllm_core::Error) -> &'static str {
     }
 }
 
-fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
+pub(crate) fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
     if prompt > 0 {
         metrics::counter!("crabllm_tokens_total",
             "provider" => ctx.provider.clone(),
@@ -62,7 +62,7 @@ fn record_tokens(ctx: &RequestContext, prompt: u32, completion: u32) {
     }
 }
 
-fn emit_usage<S: Storage, P: Provider>(
+pub(crate) fn emit_usage<S: Storage, P: Provider>(
     state: &AppState<S, P>,
     ctx: &RequestContext,
     endpoint: &'static str,
@@ -97,7 +97,7 @@ fn http_status_from_error(e: &crabllm_core::Error) -> u16 {
     }
 }
 
-fn emit_usage_error<S: Storage, P: Provider>(
+pub(crate) fn emit_usage_error<S: Storage, P: Provider>(
     state: &AppState<S, P>,
     ctx: &RequestContext,
     endpoint: &'static str,
@@ -428,16 +428,47 @@ where
 }
 
 /// GET /v1/models
-pub async fn models<S, P>(State(state): State<AppState<S, P>>) -> Json<ModelList>
+///
+/// Serves OpenAI-shaped model list by default. When the request carries an
+/// Anthropic-flavored auth header (`x-api-key` without `Authorization: Bearer`)
+/// or the `anthropic-version` header, returns Anthropic's model-list shape
+/// instead, so the official Anthropic SDKs see the response format they expect.
+pub async fn models<S, P>(State(state): State<AppState<S, P>>, headers: HeaderMap) -> Response
 where
     S: Storage + 'static,
     P: Provider + 'static,
 {
-    let data: Vec<Model> = state
+    let names: Vec<String> = state
         .registry
         .model_names()
+        .map(|n| n.to_string())
+        .collect();
+
+    if is_anthropic_client(&headers) {
+        let data: Vec<serde_json::Value> = names
+            .into_iter()
+            .map(|id| {
+                serde_json::json!({
+                    "type": "model",
+                    "id": id.clone(),
+                    "display_name": id,
+                    "created_at": "1970-01-01T00:00:00Z",
+                })
+            })
+            .collect();
+        return Json(serde_json::json!({
+            "data": data,
+            "has_more": false,
+            "first_id": null,
+            "last_id": null,
+        }))
+        .into_response();
+    }
+
+    let data: Vec<Model> = names
+        .into_iter()
         .map(|name| Model {
-            id: name.to_string(),
+            id: name,
             object: "model".to_string(),
             created: 0,
             owned_by: "crabllm".to_string(),
@@ -448,6 +479,21 @@ where
         object: "list".to_string(),
         data,
     })
+    .into_response()
+}
+
+fn is_anthropic_client(headers: &HeaderMap) -> bool {
+    if headers.contains_key("anthropic-version") {
+        return true;
+    }
+    // `x-api-key` without a Bearer Authorization header is the Anthropic SDK's
+    // default auth shape. OpenAI SDKs always send Authorization: Bearer.
+    headers.contains_key("x-api-key")
+        && !headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(|h| h.starts_with("Bearer "))
+            .unwrap_or(false)
 }
 
 /// POST /v1/images/generations
@@ -736,7 +782,7 @@ where
 
 /// Call a provider with a timeout, converting elapsed to Error::Timeout.
 /// A zero duration disables the timeout.
-async fn with_timeout<F, T>(timeout: Duration, fut: F) -> Result<T, crabllm_core::Error>
+pub(crate) async fn with_timeout<F, T>(timeout: Duration, fut: F) -> Result<T, crabllm_core::Error>
 where
     F: std::future::Future<Output = Result<T, crabllm_core::Error>>,
 {
@@ -756,7 +802,7 @@ fn jittered(backoff: Duration) -> Duration {
 }
 
 /// Retry a non-streaming chat completion on a single deployment.
-async fn try_chat_with_retries<P: Provider>(
+pub(crate) async fn try_chat_with_retries<P: Provider>(
     deployment: &Deployment<P>,
     request: &ChatCompletionRequest,
 ) -> Result<crabllm_core::ChatCompletionResponse, crabllm_core::Error> {
@@ -800,7 +846,7 @@ async fn try_chat_with_retries<P: Provider>(
 }
 
 /// Retry a streaming chat completion on a single deployment.
-async fn try_stream_with_retries<P: Provider>(
+pub(crate) async fn try_stream_with_retries<P: Provider>(
     deployment: &Deployment<P>,
     request: &ChatCompletionRequest,
 ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, crabllm_core::Error>>, crabllm_core::Error>
@@ -879,7 +925,7 @@ async fn try_embedding_with_retries<P: Provider>(
 }
 
 /// Map a provider Error to an HTTP error response.
-fn error_response(e: crabllm_core::Error) -> Response {
+pub(crate) fn error_response(e: crabllm_core::Error) -> Response {
     let (status, api_error) = match &e {
         crabllm_core::Error::Provider { status, body } => (
             StatusCode::from_u16(*status).unwrap_or(StatusCode::BAD_GATEWAY),

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -14,7 +14,7 @@ pub mod admin;
 pub mod anthropic;
 pub mod auth;
 pub mod ext;
-mod handlers;
+pub(crate) mod handlers;
 mod state;
 pub mod storage;
 
@@ -39,6 +39,7 @@ where
             "/v1/chat/completions",
             post(handlers::chat_completions::<S, P>),
         )
+        .route("/v1/messages", post(anthropic::messages::<S, P>))
         .route("/v1/embeddings", post(handlers::embeddings::<S, P>))
         .route(
             "/v1/images/generations",

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -11,6 +11,7 @@ pub use auth::KeyName;
 pub use state::{AppState, UsageEvent};
 
 pub mod admin;
+pub mod anthropic;
 pub mod auth;
 pub mod ext;
 mod handlers;


### PR DESCRIPTION
## Summary

Adds a drop-in Anthropic Messages API endpoint (`POST /v1/messages`) that sits alongside the existing OpenAI-compatible routes. Anthropic SDK clients can now point at crabllm and talk to any configured provider (OpenAI, Google, Bedrock, Azure, llama.cpp, MLX) without modification.

The handler translates the inbound `AnthropicRequest` to the internal OpenAI-shaped `ChatCompletionRequest`, runs the exact same dispatch pipeline the `/v1/chat/completions` handler uses (auth / rate-limit / cache / extensions / retries / fallback), then translates the response (or streaming chunk sequence) back to Anthropic's wire format. No changes to the `Provider` trait — all existing providers work through both endpoints.

## What's in the diff

- **Shared wire types in core** (`crates/core/src/types/anthropic.rs`). `AnthropicRequest`/`Response`/`ContentBlock`/`Usage` become bidirectional (both `Serialize` and `Deserialize`), shared by the provider crate's outbound Anthropic path and the proxy crate's new inbound path. Unified content-block enum covers both request variants (image, tool_result) and response variants (thinking), with producers only emitting what's valid for their direction. `system` upgraded to an untagged enum so we parse both the plain-string and array-of-blocks forms that real SDKs send.
- **Inbound request translator** (`crates/proxy/src/anthropic/translate.rs::to_chat_completion`). Handles system prompt (string or block-array), user blocks with interleaved `tool_result` → split into user + tool-role messages in original order, assistant blocks with interleaved thinking / text / tool_use → flat `Message` with `content` + `tool_calls` + `reasoning_content`, image sources (base64 and url) → OpenAI multimodal image_url parts, `tool_choice` mapping, and `thinking` config stashed into `request.extra` so downstream providers that speak it back (including our own outbound Anthropic translator) are symmetric.
- **Inbound response translator** (`crates/proxy/src/anthropic/translate.rs::from_chat_completion`). Maps reasoning → thinking block, content → text block, tool_calls → tool_use blocks, `FinishReason` → `stop_reason` string (`content_filter` passed through honestly rather than masked as `end_turn`), usage mapping. Returns `Result` — zero-choice responses and missing usage become provider errors rather than silently-empty responses, because corrupting billing to hide them is worse than a loud 5xx.
- **Streaming adapter** (`crates/proxy/src/anthropic/sse.rs`). `to_anthropic_sse` folds a `ChatCompletionChunk` stream into Anthropic's structured event model: `message_start → content_block_start → content_block_delta* → content_block_stop → message_delta → message_stop`. Tracks `CurrentBlock { Text | Thinking | ToolUse }` and closes the previous block when the incoming delta kind changes. Each text/thinking/tool_use block gets a fresh, monotonically-allocated Anthropic block index. On upstream error, flushes a well-formed `message_delta { stop_reason: \"error\" } + message_stop` terminator **before** yielding the error so SDK clients see the stream close cleanly instead of hanging on an aborted connection.
- **Usage accounting.** Anthropic's spec puts `input_tokens` on `message_start.usage` and `output_tokens` on `message_delta.usage`. We don't know the provider's token counts until the last chunk arrives, so `message_start.usage` is zeroed and the final totals go on `message_delta.usage`. Both the Python and TypeScript Anthropic SDKs sum these into one `Usage`, so the totals come out correct.
- **HTTP wiring** (`crates/proxy/src/anthropic/handler.rs`, `crates/proxy/src/lib.rs`). Registers `POST /v1/messages` on the same middleware stack the other routes use. Reuses the existing dispatch helpers (`try_chat_with_retries`, `try_stream_with_retries`, `emit_usage`, etc.) via `pub(crate)` exports — ~150 lines of scaffolding are duplicated from `chat_completions` because the response wrapping diverges enough that a shared helper would be uglier than the duplication it saves. Revisit if a third wire format ever shows up.
- **Auth middleware** (`crates/proxy/src/auth.rs`). Accepts `x-api-key` as a fallback to `Authorization: Bearer`. Same virtual-key lookup either way; additive across all routes.
- **`/v1/models` header sniffing** (`crates/proxy/src/handlers.rs`). When the request carries `anthropic-version` or `x-api-key` without a Bearer `Authorization` header, the handler returns Anthropic's model-list shape (`{data: [{type: \"model\", id, display_name, created_at}]}`) instead of the OpenAI one. Drop-in SDK compatibility on the one endpoint where the two specs collide.

## Drive-by fix

The existing outbound Anthropic translator at `crates/provider/src/provider/anthropic.rs::translate_response` was reading `block.text` on thinking blocks, but Anthropic's wire format uses the field name `thinking`. Reasoning content was silently dropped on non-streaming responses. Fixed by pattern-matching on the typed `AnthropicContentBlock` enum, which is now the shared type. The streaming path already handled it correctly.

## Deliberately deferred

Documented inline at the top of `translate.rs`:

- `POST /v1/messages/count_tokens` — separate endpoint, rarely used, add when a real SDK needs it.
- Prompt caching (`cache_control` blocks) — preserved opaquely in `extra` but not cache-aware dispatch yet.
- Thinking block `signature` round-trip — only load-bearing when replaying extended thinking back to the Anthropic upstream; our providers receive OpenAI-shaped `reasoning_content`.
- Non-text content inside `system` and `tool_result.content` blocks — images are dropped when nested in these positions.
- `disable_parallel_tool_use` on `tool_choice` — no internal equivalent.
- `metadata.user_id` — not currently parsed off `AnthropicRequest`.

## Commit structure

Five commits, one per phase, each torvalds-reviewed and cleaned up before landing:

1. Share wire types across crates (refactor)
2. Anthropic request → `ChatCompletionRequest`
3. `ChatCompletionResponse` → Anthropic response
4. OpenAI chunk stream → Anthropic SSE events
5. Route, auth, and `/v1/models` sniffing

Bisectable end to end. Each translator file is self-contained and compiles standalone.

## Test plan

- [ ] `cargo check --workspace` passes (verified locally).
- [ ] `cargo clippy -p crabllm-proxy` clean (verified locally).
- [ ] `cargo fmt --check` clean (verified locally).
- [ ] Point the official `anthropic` Python SDK at a local crabllm and run a non-streaming `messages.create` against an OpenAI-backed model. Verify response shape matches.
- [ ] Same, streaming. Verify block boundaries, thinking content, and final usage all reconstruct correctly client-side.
- [ ] Streaming with a tool call. Verify `content_block_start { type: tool_use }` + `input_json_delta` frames arrive in order and the SDK reconstructs the full arguments JSON.
- [ ] Streaming upstream error. Verify the client sees `message_delta { stop_reason: \"error\" } + message_stop + event: error` and the connection closes cleanly (no hang).
- [ ] Mid-stream upstream error with tool use in progress — verify current block closes before terminator.
- [ ] `GET /v1/models` with `anthropic-version: 2023-06-01` header returns Anthropic-shaped listing.
- [ ] Same request without the header returns OpenAI-shaped listing (regression check on existing clients).
- [ ] Existing OpenAI SDK integration tests still pass end-to-end.