### PR TITLE
feat(mlx): support audio input via Apple Speech framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,6 @@ dependencies = [
  "bytes",
  "clap",
  "crabllm-core",
- "crabllm-llamacpp",
  "crabllm-provider",
  "crabllm-proxy",
  "metrics-exporter-prometheus",

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -46,38 +46,6 @@ pub struct GatewayConfig {
     /// Graceful shutdown timeout in seconds. Default: 30.
     #[serde(default = "default_shutdown_timeout")]
     pub shutdown_timeout: u64,
-    /// Optional llama.cpp local backend configuration.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub llamacpp: Option<LlamaCppGatewayConfig>,
-}
-
-/// Gateway-level configuration for the llama.cpp local backend.
-///
-/// The `models` list determines which model names are registered for the
-/// llama.cpp provider. Each entry is either an Ollama-registry model name
-/// (`qwen2.5:0.5b`) or a filesystem path to a GGUF file. The pool spawns
-/// a separate `llama-server` subprocess per model on first request and
-/// evicts idle servers after `idle_timeout_secs`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct LlamaCppGatewayConfig {
-    /// Model names or GGUF paths to serve.
-    #[serde(default)]
-    pub models: Vec<String>,
-    /// Idle timeout for the per-model server pool, in seconds. Default: 1800.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub idle_timeout_secs: Option<u64>,
-    /// Number of GPU layers to offload. Default: 999 (auto).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_gpu_layers: Option<u32>,
-    /// Context size in tokens. Default: 4096.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_ctx: Option<u32>,
-    /// Number of inference threads. Default: system-chosen.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub n_threads: Option<u32>,
-    /// Override for the GGUF cache directory. Defaults to `~/.crabtalk/models`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cache_dir: Option<String>,
 }
 
 /// Configuration for a single LLM provider.
@@ -236,27 +204,6 @@ impl GatewayConfig {
     pub fn from_file(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
         let raw = std::fs::read_to_string(path)?;
         let expanded = expand_env_vars(&raw);
-
-        // Pre-parse as a generic toml::Value so we can surface a clear
-        // migration error for the removed `kind = "llamacpp"` provider
-        // variant before the typed deserialize turns it into a cryptic
-        // "unknown variant" error.
-        let raw_value: toml::Value = toml::from_str(&expanded)?;
-        if let Some(providers) = raw_value.get("providers").and_then(|v| v.as_table()) {
-            for (name, entry) in providers {
-                if let Some(kind) = entry.get("kind").and_then(|v| v.as_str())
-                    && (kind == "llamacpp" || kind == "llama_cpp")
-                {
-                    return Err(format!(
-                        "provider '{name}' uses kind = '{kind}', which is no longer supported. \
-                         Move llama.cpp configuration to a top-level [llamacpp] section. \
-                         Each model becomes an entry in llamacpp.models; pool-wide settings \
-                         (n_ctx, n_gpu_layers, n_threads, idle_timeout_secs) live under [llamacpp]."
-                    )
-                    .into());
-                }
-            }
-        }
 
         let config: GatewayConfig = toml::from_str(&expanded)?;
         Ok(config)

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 pub use config::{
-    GatewayConfig, KeyConfig, LlamaCppGatewayConfig, PricingConfig, ProviderConfig, ProviderKind,
+    GatewayConfig, KeyConfig, PricingConfig, ProviderConfig, ProviderKind,
     StorageConfig, cost,
 };
 pub use error::{ApiError, ApiErrorBody, Error};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,5 @@
 pub use config::{
-    GatewayConfig, KeyConfig, PricingConfig, ProviderConfig, ProviderKind,
-    StorageConfig, cost,
+    GatewayConfig, KeyConfig, PricingConfig, ProviderConfig, ProviderKind, StorageConfig, cost,
 };
 pub use error::{ApiError, ApiErrorBody, Error};
 pub use extension::{Extension, ExtensionError, RequestContext};

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -10,13 +10,12 @@ keywords = ["llm", "gateway", "proxy", "openai", "anthropic"]
 categories = ["command-line-utilities", "web-programming::http-server"]
 
 [features]
-default = ["rustls", "llamacpp"]
+default = ["rustls"]
 native-tls = ["crabllm-proxy/native-tls"]
 rustls = ["crabllm-proxy/rustls"]
 storage-redis = ["crabllm-proxy/storage-redis"]
 storage-sqlite = ["crabllm-proxy/storage-sqlite"]
 provider-bedrock = ["crabllm-provider/provider-bedrock"]
-llamacpp = ["dep:crabllm-llamacpp"]
 
 [[bin]]
 name = "crabllm"
@@ -24,7 +23,6 @@ path = "src/bin/main.rs"
 
 [dependencies]
 crabllm-core = { workspace = true, features = ["gateway"] }
-crabllm-llamacpp = { workspace = true, optional = true }
 crabllm-provider.workspace = true
 crabllm-proxy.workspace = true
 

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -5,8 +5,6 @@ use crabllm_core::{
     ChatCompletionResponse, EmbeddingRequest, EmbeddingResponse, Error, Extension, GatewayConfig,
     ImageRequest, MultipartField, Provider, Storage,
 };
-#[cfg(feature = "llamacpp")]
-use crabllm_llamacpp::LlamaCppProvider;
 use crabllm_provider::{ProviderRegistry, RemoteProvider};
 use crabllm_proxy::{
     AppState,
@@ -42,28 +40,6 @@ enum Commands {
         #[arg(short, long)]
         bind: Option<String>,
     },
-    /// Manage llama.cpp server and models
-    #[cfg(feature = "llamacpp")]
-    #[command(name = "llamacpp")]
-    LlamaCpp {
-        #[command(subcommand)]
-        action: LlamaCppAction,
-    },
-}
-
-#[cfg(feature = "llamacpp")]
-#[derive(Subcommand)]
-enum LlamaCppAction {
-    /// Download the llama-server binary for this platform
-    Download {
-        /// Release tag (e.g. b4567). Defaults to latest.
-        #[arg(short, long)]
-        tag: Option<String>,
-    },
-    /// Check that llama-server is installed and reachable
-    Check,
-    /// Show the resolved path to the llama-server binary
-    Which,
 }
 
 #[tokio::main]
@@ -71,83 +47,21 @@ async fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        #[cfg(feature = "llamacpp")]
-        Some(Commands::LlamaCpp { action }) => run_llamacpp(action),
         Some(Commands::Serve { config, bind }) => serve(config, bind).await,
         // Default: serve with default config path.
         None => serve(PathBuf::from("crabllm.toml"), None).await,
     }
 }
 
-#[cfg(feature = "llamacpp")]
-fn run_llamacpp(action: LlamaCppAction) {
-    match action {
-        LlamaCppAction::Download { tag } => match crabllm_llamacpp::download(tag.as_deref()) {
-            Ok(path) => {
-                eprintln!("llama-server ready at {}", path.display());
-            }
-            Err(e) => {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            }
-        },
-        LlamaCppAction::Check => {
-            match crabllm_llamacpp::find_server_binary() {
-                Ok(path) => {
-                    eprintln!("llama-server found: {}", path.display());
-                    let output = std::process::Command::new(&path).arg("--version").output();
-                    match output {
-                        Ok(out) => {
-                            // llama-server may print version to stdout or stderr.
-                            let version = String::from_utf8_lossy(&out.stdout);
-                            let version = version.trim();
-                            if !version.is_empty() {
-                                eprintln!("{version}");
-                            } else {
-                                let version = String::from_utf8_lossy(&out.stderr);
-                                let version = version.trim();
-                                if !version.is_empty() {
-                                    eprintln!("{version}");
-                                }
-                            }
-                        }
-                        Err(_) => eprintln!("(could not determine version)"),
-                    }
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    std::process::exit(1);
-                }
-            }
-        }
-        LlamaCppAction::Which => match crabllm_llamacpp::find_server_binary() {
-            Ok(path) => println!("{}", path.display()),
-            Err(e) => {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            }
-        },
-    }
-}
-
 /// Concrete provider type the gateway binary composes.
 ///
-/// Union of every provider source the binary links — remote HTTP APIs
-/// via [`RemoteProvider`] and (behind `--features llamacpp`) a local
-/// llama.cpp backend via [`LlamaCppProvider`]. The proxy crate is
-/// generic over `P: Provider`; the binary picks this enum as `P` so
-/// dispatch monomorphizes through a match/delegate with no dyn or
-/// per-call boxing.
-///
-/// `LlamaCpp` is feature-gated so a no-llamacpp build collapses to a
-/// single-variant enum with zero runtime cost. The trait methods live
-/// inline in this file because extracting them into their own file
-/// would require a sibling module under `src/bin/`, which is overkill
-/// for ~70 lines of match-delegate.
+/// The proxy crate is generic over `P: Provider`; the binary picks
+/// this enum as `P` so dispatch monomorphizes through a match/delegate
+/// with no dyn or per-call boxing. Currently a single-variant wrapper
+/// around [`RemoteProvider`] — local backends (MLX, llama.cpp) are
+/// separate binaries, not compiled into the gateway.
 enum Dispatch {
     Remote(RemoteProvider),
-    #[cfg(feature = "llamacpp")]
-    LlamaCpp(LlamaCppProvider),
 }
 
 impl Provider for Dispatch {
@@ -157,8 +71,6 @@ impl Provider for Dispatch {
     ) -> Result<ChatCompletionResponse, Error> {
         match self {
             Self::Remote(p) => p.chat_completion(request).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.chat_completion(request).await,
         }
     }
 
@@ -168,32 +80,24 @@ impl Provider for Dispatch {
     ) -> Result<BoxStream<'static, Result<ChatCompletionChunk, Error>>, Error> {
         match self {
             Self::Remote(p) => p.chat_completion_stream(request).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.chat_completion_stream(request).await,
         }
     }
 
     async fn embedding(&self, request: &EmbeddingRequest) -> Result<EmbeddingResponse, Error> {
         match self {
             Self::Remote(p) => p.embedding(request).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.embedding(request).await,
         }
     }
 
     async fn image_generation(&self, request: &ImageRequest) -> Result<(Bytes, String), Error> {
         match self {
             Self::Remote(p) => p.image_generation(request).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.image_generation(request).await,
         }
     }
 
     async fn audio_speech(&self, request: &AudioSpeechRequest) -> Result<(Bytes, String), Error> {
         match self {
             Self::Remote(p) => p.audio_speech(request).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.audio_speech(request).await,
         }
     }
 
@@ -204,84 +108,8 @@ impl Provider for Dispatch {
     ) -> Result<(Bytes, String), Error> {
         match self {
             Self::Remote(p) => p.audio_transcription(model, fields).await,
-            #[cfg(feature = "llamacpp")]
-            Self::LlamaCpp(p) => p.audio_transcription(model, fields).await,
         }
     }
-}
-
-/// Attach the llama.cpp local backend to the registry and return the
-/// pool so `serve()` can hold it alive and drive a clean shutdown.
-///
-/// The pool is constructed with the configured knobs, starts its idle
-/// monitor, and is wrapped in a single `LlamaCppProvider` that's
-/// cloned into one `Deployment` per configured model — all sharing the
-/// same pool. A startup resolution check walks every model and fails
-/// fast if its GGUF is neither cached nor a valid path, so missing
-/// models produce a clear error at boot instead of on the first chat
-/// completion.
-#[cfg(feature = "llamacpp")]
-fn wire_llamacpp(
-    registry: &mut ProviderRegistry<Dispatch>,
-    cfg: &crabllm_core::LlamaCppGatewayConfig,
-) -> Result<Arc<crabllm_llamacpp::ServerPool>, crabllm_core::Error> {
-    use crabllm_llamacpp::{ServerPool, registry as reg};
-    use crabllm_provider::Deployment;
-    use std::path::Path;
-
-    let bin = crabllm_llamacpp::find_server_binary()?;
-
-    let cache_dir = match &cfg.cache_dir {
-        Some(s) => PathBuf::from(s),
-        None => reg::default_cache_dir()?,
-    };
-
-    // Resolution check — fail fast on missing models without spawning.
-    for model in &cfg.models {
-        if reg::cached_model_path(model, &cache_dir).is_some() {
-            continue;
-        }
-        if Path::new(model).exists() {
-            continue;
-        }
-        let (name, tag) = reg::parse_model_name(model);
-        return Err(crabllm_core::Error::Config(format!(
-            "llamacpp model '{name}:{tag}' not cached. Run: crabllm-llamacpp pull {model}"
-        )));
-    }
-
-    let mut pool = ServerPool::new(bin, cache_dir);
-    if let Some(secs) = cfg.idle_timeout_secs {
-        pool = pool.with_idle_timeout(Duration::from_secs(secs));
-    }
-    if let Some(n) = cfg.n_gpu_layers {
-        pool = pool.with_gpu_layers(n);
-    }
-    if let Some(n) = cfg.n_ctx {
-        pool = pool.with_ctx_size(n);
-    }
-    if let Some(n) = cfg.n_threads {
-        pool = pool.with_threads(n);
-    }
-    let pool = Arc::new(pool);
-    pool.start_idle_monitor();
-
-    let provider = LlamaCppProvider::new(pool.clone(), crabllm_provider::make_client());
-
-    for model in &cfg.models {
-        let deployment = Deployment {
-            provider: Dispatch::LlamaCpp(provider.clone()),
-            weight: 1,
-            // Retry against a local child is pointless; the pool already
-            // serializes starts and the child is process-local.
-            max_retries: 0,
-            // Generation can legitimately run long on CPU.
-            timeout: Duration::from_secs(600),
-        };
-        registry.insert_deployment(model.clone(), "llamacpp".to_string(), deployment);
-    }
-
-    Ok(pool)
 }
 
 async fn serve(config_path: PathBuf, bind: Option<String>) {
@@ -297,8 +125,7 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
         config.listen = bind;
     }
 
-    #[cfg_attr(not(feature = "llamacpp"), expect(unused_mut))]
-    let mut registry: ProviderRegistry<Dispatch> =
+    let registry: ProviderRegistry<Dispatch> =
         match ProviderRegistry::from_config(&config, Dispatch::Remote) {
             Ok(r) => r,
             Err(e) => {
@@ -306,22 +133,6 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
                 std::process::exit(1);
             }
         };
-
-    // Wire the llama.cpp local backend if [llamacpp] is present. The
-    // returned pool is held on this stack frame so the child processes
-    // stay alive for the server's lifetime, then explicitly stopped
-    // after `run(...)` returns.
-    #[cfg(feature = "llamacpp")]
-    let llama_pool = match config.llamacpp.clone() {
-        Some(cfg) => match wire_llamacpp(&mut registry, &cfg) {
-            Ok(pool) => Some(pool),
-            Err(e) => {
-                eprintln!("error: failed to wire llamacpp: {e}");
-                std::process::exit(1);
-            }
-        },
-        None => None,
-    };
 
     let storage_kind = config
         .storage
@@ -379,14 +190,6 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
         }
     }
 
-    // Stop llama-server child processes cleanly after the gateway has
-    // drained. `LlamaCppServer::Drop` also kills the process, but
-    // calling `stop_all` here gives the idle monitor a chance to see
-    // the shutdown flag and exit without another tick.
-    #[cfg(feature = "llamacpp")]
-    if let Some(pool) = llama_pool {
-        pool.stop_all().await;
-    }
 }
 
 async fn run<S: Storage + 'static>(

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -189,7 +189,6 @@ async fn serve(config_path: PathBuf, bind: Option<String>) {
             run(config, registry, storage).await;
         }
     }
-
 }
 
 async fn run<S: Storage + 'static>(

--- a/crates/mlx/build.rs
+++ b/crates/mlx/build.rs
@@ -143,6 +143,9 @@ fn main() {
     // MLXLMCommon code even when we only ever use MLXLLM.
     println!("cargo:rustc-link-lib=framework=CoreGraphics");
     println!("cargo:rustc-link-lib=framework=CoreImage");
+    // Speech framework for SFSpeechRecognizer — used by
+    // MessageParsing.swift to transcribe `input_audio` content parts.
+    println!("cargo:rustc-link-lib=framework=Speech");
 
     // mlx-swift's C++ core (libCmlx.a) throws exceptions so the final
     // binary needs the libc++ exception runtime and personality

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -99,7 +99,6 @@ fn empty_config() -> GatewayConfig {
         pricing: HashMap::new(),
         admin_token: None,
         shutdown_timeout: 30,
-        llamacpp: None,
     }
 }
 

--- a/mlx/Sources/CrabllmMlx/MessageParsing.swift
+++ b/mlx/Sources/CrabllmMlx/MessageParsing.swift
@@ -11,6 +11,7 @@
 import CoreImage
 import Foundation
 import MLXLMCommon
+import Speech
 
 // MARK: - Message parsing
 
@@ -21,10 +22,12 @@ import MLXLMCommon
 /// Content handling:
 ///   * Plain string content (`"content": "..."`) is used as-is.
 ///   * Array-of-parts content (`"content": [{"type":"text","text":"..."},
-///     {"type":"image_url","image_url":{"url":"..."}}]`) is walked:
-///     text parts concatenated into `content`, image parts decoded
-///     into `UserInput.Image` values and attached to the message.
-///     Audio and other unknown part types are dropped.
+///     {"type":"image_url","image_url":{"url":"..."}},
+///     {"type":"input_audio","input_audio":{"data":"<base64>","format":"wav"}}]`)
+///     is walked: text parts concatenated into `content`, image parts
+///     decoded into `UserInput.Image` values and attached to the
+///     message, audio parts transcribed via `SFSpeechRecognizer` and
+///     appended to the text buffer. Other unknown part types are dropped.
 ///   * Missing / null / non-string / non-array content becomes "".
 ///
 /// Image URLs in `image_url` parts may be any of:
@@ -139,6 +142,14 @@ func parseContent(_ value: Any?) throws -> (text: String, images: [UserInput.Ima
                 throw FFIError.invalidArg("image_url part is missing url")
             }
             images.append(try decodeImageURL(urlStr))
+        case "input_audio":
+            guard let audioObj = part["input_audio"] as? [String: Any],
+                  let b64 = audioObj["data"] as? String, !b64.isEmpty
+            else {
+                throw FFIError.invalidArg("input_audio part is missing data")
+            }
+            let format = (audioObj["format"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "wav"
+            text.append(try transcribeAudio(data: b64, format: format))
         default:
             continue
         }
@@ -216,6 +227,91 @@ func fetchImageBytes(_ url: URL) throws -> Data {
         throw FFIError.invalidArg("image_url fetch returned no data")
     }
     return data
+}
+
+/// Transcribe base64-encoded audio via Apple's `SFSpeechRecognizer`.
+///
+/// Same threading contract as `fetchImageBytes` — the FFI call runs
+/// on a dedicated `spawn_blocking` worker, so blocking on a
+/// `DispatchSemaphore` is safe. The recognizer runs on CPU/ANE,
+/// leaving the GPU free for MLX inference.
+///
+/// The `format` parameter becomes the temp file extension so
+/// `SFSpeechURLRecognitionRequest` can detect the audio codec
+/// (wav, mp3, m4a, etc.). Authorization is requested on first use;
+/// if the user denies it, subsequent calls fail immediately.
+private let audioTranscriptionTimeout: TimeInterval = 60
+
+func transcribeAudio(data b64: String, format: String) throws -> String {
+    // Request authorization if not yet determined.
+    let status = SFSpeechRecognizer.authorizationStatus()
+    if status == .notDetermined {
+        let authSemaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var granted = false
+        SFSpeechRecognizer.requestAuthorization { s in
+            granted = (s == .authorized)
+            authSemaphore.signal()
+        }
+        if authSemaphore.wait(timeout: .now() + 120) == .timedOut {
+            throw FFIError.invalidArg(
+                "input_audio: speech recognition authorization prompt timed out"
+            )
+        }
+        if !granted {
+            throw FFIError.invalidArg(
+                "input_audio: speech recognition authorization denied — "
+                + "grant permission in System Settings → Privacy & Security → Speech Recognition"
+            )
+        }
+    } else if status != .authorized {
+        throw FFIError.invalidArg(
+            "input_audio: speech recognition not authorized (status \(status.rawValue)) — "
+            + "grant permission in System Settings → Privacy & Security → Speech Recognition"
+        )
+    }
+
+    guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+        throw FFIError.invalidArg("input_audio: SFSpeechRecognizer is not available")
+    }
+    guard let audioData = Data(base64Encoded: b64) else {
+        throw FFIError.invalidArg("input_audio: base64 payload failed to decode")
+    }
+
+    // Write to a temp file — SFSpeechURLRecognitionRequest needs a file URL.
+    let tempFile = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+        .appendingPathExtension(format)
+    try audioData.write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let request = SFSpeechURLRecognitionRequest(url: tempFile)
+    request.shouldReportPartialResults = false
+
+    let semaphore = DispatchSemaphore(value: 0)
+    nonisolated(unsafe) var transcript: String?
+    nonisolated(unsafe) var recognitionError: Error?
+
+    let task = recognizer.recognitionTask(with: request) { result, error in
+        if let error = error {
+            recognitionError = error
+            semaphore.signal()
+            return
+        }
+        if let result = result, result.isFinal {
+            transcript = result.bestTranscription.formattedString
+            semaphore.signal()
+        }
+    }
+
+    let waitDeadline = DispatchTime.now() + audioTranscriptionTimeout
+    if semaphore.wait(timeout: waitDeadline) == .timedOut {
+        task.cancel()
+        throw FFIError.invalidArg("input_audio: transcription exceeded \(Int(audioTranscriptionTimeout))s timeout")
+    }
+    if let error = recognitionError {
+        throw FFIError.invalidArg("input_audio: transcription failed: \(error)")
+    }
+    return transcript ?? ""
 }
 
 /// Decode a `data:[<mediatype>];base64,<payload>` URL. Anchors on the


### PR DESCRIPTION
Closes #56.

## Audio input via SFSpeechRecognizer

Transcribe `input_audio` content parts via `SFSpeechRecognizer` in `MessageParsing.swift`, right next to the existing `image_url` decoding. Base64 audio is written to a temp file, transcribed on CPU/ANE via Apple's Speech framework, and the transcript replaces the audio part as text — the MLX model sees only text + images.

- `case "input_audio"` in `parseContent` alongside `"text"` and `"image_url"`, matching the OpenAI `input_audio` content part shape (`{"type":"input_audio","input_audio":{"data":"<base64>","format":"wav"}}`)
- `transcribeAudio(data:format:)` — same semaphore-based sync pattern as `fetchImageBytes`, with auth request on first use, task cancellation on timeout, temp file cleanup via `defer`
- `Speech.framework` linked in `build.rs` — ships with macOS 14+, zero new dependencies
- No C ABI changes, no Rust changes

Interim solution until #57 (native audio encoder in `mlx-swift-lm`) lands upstream.

## Remove llamacpp from gateway binary

`crabllm-llamacpp` is a standalone provider like `crabllm-mlx` — it doesn't belong compiled into the gateway. Removed the feature gate, `Dispatch::LlamaCpp` variant, CLI subcommand, `wire_llamacpp()` plumbing, `LlamaCppGatewayConfig`, and the config migration shim. The `crabllm-llamacpp` crate stays in the workspace unchanged.