### PR TITLE
feat(proxy): dynamic provider registration without process restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +459,7 @@ dependencies = [
 name = "crabllm"
 version = "0.0.15"
 dependencies = [
+ "arc-swap",
  "axum",
  "bytes",
  "clap",
@@ -552,6 +562,7 @@ dependencies = [
 name = "crabllm-proxy"
 version = "0.0.15"
 dependencies = [
+ "arc-swap",
  "axum",
  "bytes",
  "crabllm-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ flate2 = "1"
 tar = "0.4"
 zip = { version = "8", default-features = false, features = ["deflate"] }
 dirs = "6"
+arc-swap = "1"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -27,6 +27,7 @@ crabllm-provider.workspace = true
 crabllm-proxy.workspace = true
 
 # crates-io
+arc-swap.workspace = true
 axum.workspace = true
 bytes.workspace = true
 clap.workspace = true

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwap;
 use bytes::Bytes;
 use clap::{Parser, Subcommand};
 use crabllm_core::{
@@ -255,6 +256,7 @@ async fn run<S: Storage + 'static>(
     let model_count = registry.model_names().count();
     let provider_count = registry.provider_count();
     let shutdown_timeout = Duration::from_secs(config.shutdown_timeout);
+    let registry = Arc::new(ArcSwap::from_pointee(registry));
 
     // Build key_map from TOML config keys.
     let key_map: HashMap<String, String> = config
@@ -284,8 +286,18 @@ async fn run<S: Storage + 'static>(
             storage.clone() as Arc<dyn crabllm_core::Storage>,
             model_overrides.clone(),
             config.clone(),
+            config_path.clone(),
+            admin_token.clone(),
+        ));
+        let rebuilder: crabllm_proxy::admin_providers::Rebuilder<Dispatch> =
+            Arc::new(|config: &GatewayConfig| {
+                ProviderRegistry::from_config(config, Dispatch::Remote)
+            });
+        admin_routes.push(crabllm_proxy::admin_providers::provider_admin_routes(
+            registry.clone(),
             config_path,
             admin_token.clone(),
+            rebuilder,
         ));
     }
 

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -20,6 +20,7 @@ crabllm-core = { workspace = true, features = ["gateway"] }
 crabllm-provider.workspace = true
 
 # crates-io
+arc-swap.workspace = true
 axum.workspace = true
 bytes.workspace = true
 dashmap.workspace = true

--- a/crates/proxy/src/admin_providers.rs
+++ b/crates/proxy/src/admin_providers.rs
@@ -92,7 +92,7 @@ struct ReloadResponse {
 /// POST /v1/admin/providers/reload — re-read config from disk and
 /// atomically swap the provider registry.
 async fn reload_providers<P: Provider>(State(state): State<ProviderAdminState<P>>) -> Response {
-    let raw = match std::fs::read_to_string(&state.config_path) {
+    let raw = match tokio::fs::read_to_string(&state.config_path).await {
         Ok(s) => s,
         Err(e) => {
             return (

--- a/crates/proxy/src/admin_providers.rs
+++ b/crates/proxy/src/admin_providers.rs
@@ -91,9 +91,7 @@ struct ReloadResponse {
 
 /// POST /v1/admin/providers/reload — re-read config from disk and
 /// atomically swap the provider registry.
-async fn reload_providers<P: Provider>(
-    State(state): State<ProviderAdminState<P>>,
-) -> Response {
+async fn reload_providers<P: Provider>(State(state): State<ProviderAdminState<P>>) -> Response {
     let raw = match std::fs::read_to_string(&state.config_path) {
         Ok(s) => s,
         Err(e) => {

--- a/crates/proxy/src/admin_providers.rs
+++ b/crates/proxy/src/admin_providers.rs
@@ -1,0 +1,150 @@
+use arc_swap::ArcSwap;
+use axum::{
+    Json, Router,
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use crabllm_core::{ApiError, Error, GatewayConfig, Provider};
+use crabllm_provider::ProviderRegistry;
+use serde::Serialize;
+use std::{path::PathBuf, sync::Arc};
+
+/// A closure that rebuilds the provider registry from a config.
+/// The binary provides this because the proxy crate doesn't know the
+/// concrete `P` construction path (e.g. `Dispatch::Remote`).
+pub type Rebuilder<P> =
+    Arc<dyn Fn(&GatewayConfig) -> Result<ProviderRegistry<P>, Error> + Send + Sync>;
+
+struct ProviderAdminState<P: Provider> {
+    registry: Arc<ArcSwap<ProviderRegistry<P>>>,
+    config_path: PathBuf,
+    admin_token: String,
+    rebuilder: Rebuilder<P>,
+}
+
+impl<P: Provider> Clone for ProviderAdminState<P> {
+    fn clone(&self) -> Self {
+        Self {
+            registry: self.registry.clone(),
+            config_path: self.config_path.clone(),
+            admin_token: self.admin_token.clone(),
+            rebuilder: self.rebuilder.clone(),
+        }
+    }
+}
+
+/// Build admin provider management routes, protected by admin token auth.
+pub fn provider_admin_routes<P: Provider + 'static>(
+    registry: Arc<ArcSwap<ProviderRegistry<P>>>,
+    config_path: PathBuf,
+    admin_token: String,
+    rebuilder: Rebuilder<P>,
+) -> Router {
+    let state = ProviderAdminState {
+        registry,
+        config_path,
+        admin_token,
+        rebuilder,
+    };
+    Router::new()
+        .route("/v1/admin/providers/reload", post(reload_providers::<P>))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            admin_auth::<P>,
+        ))
+        .with_state(state)
+}
+
+async fn admin_auth<P: Provider>(
+    State(state): State<ProviderAdminState<P>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let token = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
+
+    match token {
+        Some(t) if crate::admin::constant_time_eq(t, &state.admin_token) => next.run(request).await,
+        _ => (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiError::new(
+                "missing or invalid admin token",
+                "authentication_error",
+            )),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Serialize)]
+struct ReloadResponse {
+    status: &'static str,
+    models: usize,
+    providers: usize,
+}
+
+/// POST /v1/admin/providers/reload — re-read config from disk and
+/// atomically swap the provider registry.
+async fn reload_providers<P: Provider>(
+    State(state): State<ProviderAdminState<P>>,
+) -> Response {
+    let raw = match std::fs::read_to_string(&state.config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::new(
+                    format!("failed to read config file: {e}"),
+                    "server_error",
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let config: GatewayConfig = match toml::from_str(&raw) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError::new(
+                    format!("failed to parse config: {e}"),
+                    "invalid_request_error",
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let new_registry = match (state.rebuilder)(&config) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ApiError::new(
+                    format!("failed to build registry: {e}"),
+                    "invalid_request_error",
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let models = new_registry.model_names().count();
+    let providers = new_registry.provider_count();
+    state.registry.store(Arc::new(new_registry));
+    eprintln!("provider registry reloaded: {models} models, {providers} providers");
+
+    Json(ReloadResponse {
+        status: "ok",
+        models,
+        providers,
+    })
+    .into_response()
+}

--- a/crates/proxy/src/anthropic/handler.rs
+++ b/crates/proxy/src/anthropic/handler.rs
@@ -62,8 +62,9 @@ where
         }
     };
     let is_stream = peek.stream == Some(true);
-    let model = state.registry.resolve(&peek.model).to_string();
-    let deployments = match state.registry.dispatch_list(&model) {
+    let registry = state.registry();
+    let model = registry.resolve(&peek.model).to_string();
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -99,8 +100,7 @@ where
     };
     let mut request = to_chat_completion(anthropic_req);
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();
@@ -348,8 +348,8 @@ async fn handle_raw_anthropic<S: Storage, P: Provider>(
         output_tokens: u32,
     }
 
-    let provider_name = state
-        .registry
+    let registry = state.registry();
+    let provider_name = registry
         .provider_name(model)
         .unwrap_or_default()
         .to_string();

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -149,8 +149,9 @@ where
         }
     };
     let is_stream = peek.stream == Some(true);
-    let model = state.registry.resolve(&peek.model).to_string();
-    let deployments = match state.registry.dispatch_list(&model) {
+    let registry = state.registry();
+    let model = registry.resolve(&peek.model).to_string();
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -187,8 +188,7 @@ where
         }
     };
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();
@@ -404,8 +404,8 @@ async fn handle_raw_proxy<S: Storage, P: Provider>(
     deployments: &[&Deployment<P>],
     raw_body: axum::body::Bytes,
 ) -> Response {
-    let provider_name = state
-        .registry
+    let registry = state.registry();
+    let provider_name = registry
         .provider_name(model)
         .unwrap_or_default()
         .to_string();
@@ -474,8 +474,9 @@ where
     S: Storage + 'static,
     P: Provider + 'static,
 {
-    let model = state.registry.resolve(&request.model).to_string();
-    let deployments = match state.registry.dispatch_list(&model) {
+    let registry = state.registry();
+    let model = registry.resolve(&request.model).to_string();
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -489,8 +490,7 @@ where
         }
     };
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();
@@ -556,8 +556,8 @@ where
     S: Storage + 'static,
     P: Provider + 'static,
 {
-    let names: Vec<String> = state
-        .registry
+    let registry = state.registry();
+    let names: Vec<String> = registry
         .model_names()
         .map(|n| n.to_string())
         .collect();
@@ -636,8 +636,9 @@ where
     S: Storage + 'static,
     P: Provider + 'static,
 {
-    let model = state.registry.resolve(&request.model).to_string();
-    let deployments = match state.registry.dispatch_list(&model) {
+    let registry = state.registry();
+    let model = registry.resolve(&request.model).to_string();
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -651,8 +652,7 @@ where
         }
     };
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();
@@ -714,8 +714,9 @@ where
     S: Storage + 'static,
     P: Provider + 'static,
 {
-    let model = state.registry.resolve(&request.model).to_string();
-    let deployments = match state.registry.dispatch_list(&model) {
+    let registry = state.registry();
+    let model = registry.resolve(&request.model).to_string();
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -729,8 +730,7 @@ where
         }
     };
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();
@@ -828,8 +828,9 @@ where
         });
     }
 
+    let registry = state.registry();
     let model = match model_value {
-        Some(m) => state.registry.resolve(&m).to_string(),
+        Some(m) => registry.resolve(&m).to_string(),
         None => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -842,7 +843,7 @@ where
         }
     };
 
-    let deployments = match state.registry.dispatch_list(&model) {
+    let deployments = match registry.dispatch_list(&model) {
         Some(list) => list,
         None => {
             return (
@@ -856,8 +857,7 @@ where
         }
     };
 
-    let provider_name = state
-        .registry
+    let provider_name = registry
         .provider_name(&model)
         .unwrap_or_default()
         .to_string();

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -557,10 +557,7 @@ where
     P: Provider + 'static,
 {
     let registry = state.registry();
-    let names: Vec<String> = registry
-        .model_names()
-        .map(|n| n.to_string())
-        .collect();
+    let names: Vec<String> = registry.model_names().map(|n| n.to_string()).collect();
 
     if is_anthropic_client(&headers) {
         let data: Vec<serde_json::Value> = names

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -12,6 +12,7 @@ pub use state::{AppState, UsageEvent};
 
 pub mod admin;
 pub mod admin_models;
+pub mod admin_providers;
 pub mod anthropic;
 pub mod auth;
 pub mod ext;

--- a/crates/proxy/src/state.rs
+++ b/crates/proxy/src/state.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwap;
 use crabllm_core::{Extension, GatewayConfig, ModelInfo, Provider, Storage};
 use crabllm_provider::ProviderRegistry;
 use std::{
@@ -48,7 +49,7 @@ pub struct UsageEvent {
 /// every provider source it links — that enum implements `Provider` via
 /// match-and-delegate, so dispatch through `P` is fully monomorphized.
 pub struct AppState<S: Storage, P: Provider> {
-    pub registry: ProviderRegistry<P>,
+    pub registry: Arc<ArcSwap<ProviderRegistry<P>>>,
     pub config: GatewayConfig,
     pub extensions: Arc<Vec<Box<dyn Extension>>>,
     pub storage: Arc<S>,
@@ -77,5 +78,14 @@ impl<S: Storage, P: Provider> Clone for AppState<S, P> {
             model_overrides: self.model_overrides.clone(),
             usage_events: self.usage_events.clone(),
         }
+    }
+}
+
+impl<S: Storage, P: Provider> AppState<S, P> {
+    /// Snapshot the current provider registry. Returns a guard that
+    /// keeps the referenced registry alive for the duration of the
+    /// request — even if a concurrent swap replaces the global pointer.
+    pub fn registry(&self) -> arc_swap::Guard<Arc<ProviderRegistry<P>>> {
+        self.registry.load()
     }
 }

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -12,6 +12,7 @@ use crabllm_core::{
     BoxFuture, BoxStream, ChatCompletionRequest, ChatCompletionResponse, Choice, Error,
     FinishReason, GatewayConfig, KvPairs, Message, Prefix, Provider, Role, Storage, Usage,
 };
+use arc_swap::ArcSwap;
 use crabllm_provider::{Deployment, ProviderRegistry};
 use crabllm_proxy::{AppState, UsageEvent, router};
 use std::{
@@ -96,7 +97,9 @@ fn empty_config() -> GatewayConfig {
         extensions: None,
         storage: None,
         aliases: HashMap::new(),
-        pricing: HashMap::new(),
+        models: HashMap::new(),
+        cloud_models: None,
+        local_models: None,
         admin_token: None,
         shutdown_timeout: 30,
     }
@@ -119,11 +122,12 @@ fn build_state(tx: broadcast::Sender<UsageEvent>) -> AppState<FakeStorage, FakeP
     let registry = ProviderRegistry::new(providers, HashMap::new(), model_providers);
 
     AppState {
-        registry,
+        registry: Arc::new(ArcSwap::from_pointee(registry)),
         config: empty_config(),
         extensions: Arc::new(Vec::new()),
         storage: Arc::new(FakeStorage),
         key_map: Arc::new(RwLock::new(HashMap::new())),
+        model_overrides: Arc::new(RwLock::new(HashMap::new())),
         usage_events: Some(tx),
     }
 }
@@ -189,11 +193,12 @@ async fn none_usage_events_is_zero_cost() {
     let registry = ProviderRegistry::new(providers, HashMap::new(), model_providers);
 
     let state = AppState::<FakeStorage, FakeProvider> {
-        registry,
+        registry: Arc::new(ArcSwap::from_pointee(registry)),
         config: empty_config(),
         extensions: Arc::new(Vec::new()),
         storage: Arc::new(FakeStorage),
         key_map: Arc::new(RwLock::new(HashMap::new())),
+        model_overrides: Arc::new(RwLock::new(HashMap::new())),
         usage_events: None,
     };
 

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -4,6 +4,7 @@
 //! provider and storage, subscribes to `usage_events`, and asserts
 //! that exactly one event arrives with the expected shape.
 
+use arc_swap::ArcSwap;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -12,7 +13,6 @@ use crabllm_core::{
     BoxFuture, BoxStream, ChatCompletionRequest, ChatCompletionResponse, Choice, Error,
     FinishReason, GatewayConfig, KvPairs, Message, Prefix, Provider, Role, Storage, Usage,
 };
-use arc_swap::ArcSwap;
 use crabllm_provider::{Deployment, ProviderRegistry};
 use crabllm_proxy::{AppState, UsageEvent, router};
 use std::{


### PR DESCRIPTION
## Summary

- Wrap `ProviderRegistry<P>` in `Arc<ArcSwap<...>>` inside `AppState` so readers get lock-free snapshots via `state.registry()` and writers can atomically swap in a new registry with zero contention on the read path.
- Add `POST /v1/admin/providers/reload` — re-reads the config file from disk, rebuilds the provider registry through a binary-supplied `Rebuilder<P>` closure, and atomically swaps it in. In-flight requests on the old registry are unaffected (their `Guard` keeps the old `Arc` alive).
- Fix pre-existing test breakage in `usage_events.rs` (stale `GatewayConfig` fields, missing `model_overrides`).

Closes #60

## Test plan

- [x] `cargo check -p crabllm-proxy -p crabllm` — compiles clean
- [x] `cargo test -p crabllm-proxy` — 2/2 tests pass, no warnings
- [ ] Manual: start server with `admin_token` configured, `POST /v1/admin/providers/reload` with admin bearer token, verify response shows updated model/provider counts
- [ ] Manual: verify in-flight streaming requests complete normally during a reload