### PR TITLE
feat(proxy): unified admin API with per-key rate limits, usage scoping, and OpenAPI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +479,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-scalar",
 ]
 
 [[package]]
@@ -494,6 +505,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "utoipa",
 ]
 
 [[package]]
@@ -583,6 +595,7 @@ dependencies = [
  "toml",
  "tower",
  "tracing",
+ "utoipa",
  "uuid",
 ]
 
@@ -2288,6 +2301,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rend"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3550,6 +3592,42 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ dirs = "6"
 arc-swap = "1"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
+utoipa = { version = "5", features = ["axum_extras"] }
+utoipa-scalar = { version = "0.3", features = ["axum"] }
 
 [profile.prod]
 inherits = "release"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["data-structures", "web-programming"]
 
 [features]
 gateway = ["toml"]
+openapi = ["utoipa"]
 
 [dependencies]
 # crates-io
@@ -19,3 +20,4 @@ futures-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml = { workspace = true, optional = true }
+utoipa = { workspace = true, optional = true }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -172,6 +172,16 @@ impl ProviderConfig {
     }
 }
 
+/// Per-key rate limit override. When set on a key, these values take
+/// precedence over the global `[extensions.rate_limit]` config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyRateLimit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requests_per_minute: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_per_minute: Option<u64>,
+}
+
 /// Virtual API key for client authentication.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyConfig {
@@ -181,6 +191,10 @@ pub struct KeyConfig {
     pub key: String,
     /// Which models this key can access. `["*"]` means all.
     pub models: Vec<String>,
+    /// Per-key rate limit override. Takes precedence over the global
+    /// `[extensions.rate_limit]` config when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rate_limit: Option<KeyRateLimit>,
 }
 
 /// Storage backend configuration.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 
 /// Per-model token pricing configuration.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct PricingConfig {
     /// Cost per million prompt tokens in USD.
     pub prompt_cost_per_million: f64,
@@ -48,6 +49,9 @@ pub struct GatewayConfig {
     /// Graceful shutdown timeout in seconds. Default: 30.
     #[serde(default = "default_shutdown_timeout")]
     pub shutdown_timeout: u64,
+    /// Enable OpenAPI documentation at /openapi.json and /docs.
+    #[serde(default)]
+    pub openapi: bool,
 }
 
 /// Configuration for a single LLM provider.
@@ -175,6 +179,7 @@ impl ProviderConfig {
 /// Per-key rate limit override. When set on a key, these values take
 /// precedence over the global `[extensions.rate_limit]` config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct KeyRateLimit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requests_per_minute: Option<u64>,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -75,11 +75,13 @@ impl From<serde_json::Error> for Error {
 
 /// OpenAI-compatible error response returned to clients.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ApiError {
     pub error: ApiErrorBody,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ApiErrorBody {
     pub message: String,
     #[serde(rename = "type")]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 pub use config::{
-    GatewayConfig, KeyConfig, LocalModelEntry, PricingConfig, ProviderConfig, ProviderKind,
-    StorageConfig,
+    GatewayConfig, KeyConfig, KeyRateLimit, LocalModelEntry, PricingConfig, ProviderConfig,
+    ProviderKind, StorageConfig,
 };
 pub use error::{ApiError, ApiErrorBody, Error};
 pub use extension::{Extension, ExtensionError, RequestContext};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,8 @@ mod config;
 mod error;
 mod extension;
 mod model_info;
+#[cfg(feature = "openapi")]
+mod openapi;
 mod provider;
 mod storage;
 mod types;

--- a/crates/core/src/model_info.rs
+++ b/crates/core/src/model_info.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 /// that sets only `context_length` inherits pricing from the static
 /// default via [`ModelInfo::merge`].
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelInfo {
     /// Maximum context window in tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/openapi.rs
+++ b/crates/core/src/openapi.rs
@@ -1,0 +1,63 @@
+//! Manual `ToSchema` implementations for types with custom Serialize/Deserialize.
+//!
+//! Types that derive Serialize get `#[cfg_attr(feature = "openapi", derive(ToSchema))]`
+//! directly. Types with custom impls need manual schemas here because utoipa's
+//! derive macro can't infer the schema from custom serialization logic.
+
+use utoipa::openapi::schema::{ObjectBuilder, SchemaType, Type};
+
+use crate::{EmbeddingInput, FinishReason, Role, Stop, ToolChoice};
+
+macro_rules! string_schema {
+    ($ty:ty, $desc:expr, $($variant:literal),+ $(,)?) => {
+        impl utoipa::PartialSchema for $ty {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                ObjectBuilder::new()
+                    .schema_type(SchemaType::new(Type::String))
+                    .description(Some($desc))
+                    .enum_values::<[&str; 0], &str>(None)
+                    .build()
+                    .into()
+            }
+        }
+        impl utoipa::ToSchema for $ty {}
+    };
+}
+
+macro_rules! any_schema {
+    ($ty:ty, $desc:expr) => {
+        impl utoipa::PartialSchema for $ty {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                ObjectBuilder::new().description(Some($desc)).build().into()
+            }
+        }
+        impl utoipa::ToSchema for $ty {}
+    };
+}
+
+string_schema!(
+    Role,
+    "One of: user, assistant, system, tool, developer",
+    "user",
+    "assistant",
+    "system",
+    "tool",
+    "developer"
+);
+string_schema!(
+    FinishReason,
+    "One of: stop, length, tool_calls, content_filter",
+    "stop",
+    "length",
+    "tool_calls",
+    "content_filter"
+);
+any_schema!(
+    ToolChoice,
+    "String (\"none\", \"auto\", \"required\") or object {\"type\":\"function\",\"function\":{\"name\":\"...\"}}"
+);
+any_schema!(
+    Stop,
+    "A string or array of strings where the model should stop"
+);
+any_schema!(EmbeddingInput, "A string or array of strings to embed");

--- a/crates/core/src/types/audio.rs
+++ b/crates/core/src/types/audio.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AudioSpeechRequest {
     pub model: String,
     pub input: String,

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -86,6 +86,7 @@ impl<'de> Deserialize<'de> for FinishReason {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ToolType {
     #[serde(rename = "function")]
     #[default]
@@ -159,6 +160,7 @@ impl From<&str> for ToolChoice {
 // ── Request ──
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChatCompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
@@ -199,6 +201,7 @@ pub enum Stop {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Message {
     pub role: Role,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -269,6 +272,7 @@ impl Message {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ToolCall {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub index: Option<u32>,
@@ -279,12 +283,14 @@ pub struct ToolCall {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FunctionCall {
     pub name: String,
     pub arguments: String,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Tool {
     #[serde(rename = "type")]
     pub kind: ToolType,
@@ -294,6 +300,7 @@ pub struct Tool {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FunctionDef {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -305,6 +312,7 @@ pub struct FunctionDef {
 // ── Response ──
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChatCompletionResponse {
     pub id: String,
     pub object: String,
@@ -318,6 +326,7 @@ pub struct ChatCompletionResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Choice {
     pub index: u32,
     pub message: Message,
@@ -367,6 +376,7 @@ impl ChatCompletionResponse {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
@@ -380,6 +390,7 @@ pub struct Usage {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CompletionTokensDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u32>,
@@ -388,6 +399,7 @@ pub struct CompletionTokensDetails {
 // ── Streaming ──
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChatCompletionChunk {
     pub id: String,
     pub object: String,
@@ -440,6 +452,7 @@ impl ChatCompletionChunk {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChunkChoice {
     pub index: u32,
     pub delta: Delta,
@@ -450,6 +463,7 @@ pub struct ChunkChoice {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Delta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<Role>,
@@ -462,6 +476,7 @@ pub struct Delta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ToolCallDelta {
     pub index: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -474,6 +489,7 @@ pub struct ToolCallDelta {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FunctionCallDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,

--- a/crates/core/src/types/embedding.rs
+++ b/crates/core/src/types/embedding.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EmbeddingRequest {
     pub model: String,
     pub input: EmbeddingInput,
@@ -14,6 +15,7 @@ pub enum EmbeddingInput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EmbeddingResponse {
     pub object: String,
     pub data: Vec<Embedding>,
@@ -22,6 +24,7 @@ pub struct EmbeddingResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Embedding {
     pub object: String,
     pub index: u32,
@@ -29,6 +32,7 @@ pub struct Embedding {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EmbeddingUsage {
     pub prompt_tokens: u32,
     pub total_tokens: u32,

--- a/crates/core/src/types/image.rs
+++ b/crates/core/src/types/image.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ImageRequest {
     pub model: String,
     pub prompt: String,

--- a/crates/core/src/types/model.rs
+++ b/crates/core/src/types/model.rs
@@ -2,6 +2,7 @@ use crate::PricingConfig;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Model {
     pub id: String,
     pub object: String,
@@ -16,6 +17,7 @@ pub struct Model {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelList {
     pub object: String,
     pub data: Vec<Model>,

--- a/crates/crabllm/Cargo.toml
+++ b/crates/crabllm/Cargo.toml
@@ -16,6 +16,7 @@ rustls = ["crabllm-proxy/rustls"]
 storage-redis = ["crabllm-proxy/storage-redis"]
 storage-sqlite = ["crabllm-proxy/storage-sqlite"]
 provider-bedrock = ["crabllm-provider/provider-bedrock"]
+openapi = ["crabllm-proxy/openapi", "utoipa", "utoipa-scalar"]
 
 [[bin]]
 name = "crabllm"
@@ -35,3 +36,5 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 metrics-exporter-prometheus.workspace = true
+utoipa = { workspace = true, optional = true }
+utoipa-scalar = { workspace = true, optional = true }

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -266,6 +266,16 @@ async fn run<S: Storage + 'static>(
         .collect();
     let key_map = Arc::new(RwLock::new(key_map));
 
+    // Persist TOML key configs to storage so extensions (rate limiter,
+    // etc.) can look up per-key config without a separate in-memory map.
+    // Overwrites on every startup to reflect config edits.
+    for kc in &config.keys {
+        let skey = crabllm_core::storage_key(&crabllm_proxy::PREFIX_KEYS, kc.name.as_bytes());
+        if let Ok(value) = serde_json::to_vec(kc) {
+            let _ = storage.set(&skey, value).await;
+        }
+    }
+
     // Load stored keys and merge (TOML takes precedence on conflicts).
     crabllm_proxy::admin::load_stored_keys(
         storage.as_ref() as &dyn crabllm_core::Storage,

--- a/crates/crabllm/src/bin/main.rs
+++ b/crates/crabllm/src/bin/main.rs
@@ -311,6 +311,9 @@ async fn run<S: Storage + 'static>(
         ));
     }
 
+    #[cfg(feature = "openapi")]
+    let enable_openapi = config.openapi;
+
     let state: AppState<S, Dispatch> = AppState {
         registry,
         config,
@@ -321,7 +324,22 @@ async fn run<S: Storage + 'static>(
         usage_events: None,
     };
 
-    let app = crabllm_proxy::router(state, admin_routes);
+    #[allow(unused_mut)]
+    let mut app = crabllm_proxy::router(state, admin_routes);
+
+    #[cfg(feature = "openapi")]
+    if enable_openapi {
+        use utoipa_scalar::Servable;
+        let spec = crabllm_proxy::openapi::spec();
+        app = app
+            .merge(utoipa_scalar::Scalar::with_url("/docs", spec.clone()))
+            .route(
+                "/openapi.json",
+                axum::routing::get(move || async { axum::Json(spec) }),
+            );
+        eprintln!("openapi docs enabled at /docs");
+    }
+
     let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(l) => l,
         Err(e) => {

--- a/crates/mlx/Cargo.toml
+++ b/crates/mlx/Cargo.toml
@@ -31,6 +31,9 @@ rand.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+[build-dependencies]
+toml.workspace = true
+
 [dev-dependencies]
 base64.workspace = true
 clap.workspace = true

--- a/crates/mlx/build.rs
+++ b/crates/mlx/build.rs
@@ -311,7 +311,6 @@ fn generate_model_registry(mlx_dir: &Path) {
     fs::write(&registry_path, &code).expect("write model_registry.rs");
 }
 
-
 /// Parse `models/local.toml` into registry entries.
 ///
 /// The TOML uses nested tables `[models.family.size.quant]` with fields

--- a/crates/mlx/build.rs
+++ b/crates/mlx/build.rs
@@ -27,7 +27,7 @@ fn main() {
         let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
         fs::write(
             out_dir.join("model_registry.rs"),
-            "pub const MODEL_REGISTRY: &[(&str, &str, &str, ModelKind)] = &[];\n",
+            "pub const MODEL_REGISTRY: &[(&str, &str, ModelKind, u64)] = &[];\n",
         )
         .expect("write empty model_registry.rs");
         return;
@@ -280,33 +280,29 @@ fn compile_metallib(mlx_dir: &Path) {
     println!("cargo:rustc-env=MLX_METALLIB_PATH={}", metallib.display());
 }
 
-/// Parse `LLMModelFactory.swift` + `VLMModelFactory.swift` and generate
-/// a Rust registry of supported models at `$OUT_DIR/model_registry.rs`.
+/// Parse `models/local.toml` and generate a Rust registry at
+/// `$OUT_DIR/model_registry.rs`.
 ///
 /// The `kind` column is emitted as a `ModelKind` variant, not a string
 /// tag — `ModelKind` is already in scope inside the generated file via
 /// `include!`, so the enum invariant is enforced by rustc at build time
 /// and no runtime parse / panic branch exists.
 fn generate_model_registry(mlx_dir: &Path) {
-    let llm_factory =
-        mlx_dir.join(".build/checkouts/mlx-swift-lm/Libraries/MLXLLM/LLMModelFactory.swift");
-    let vlm_factory =
-        mlx_dir.join(".build/checkouts/mlx-swift-lm/Libraries/MLXVLM/VLMModelFactory.swift");
+    let workspace_root = mlx_dir.parent().expect("mlx_dir has parent");
+    let local_toml = workspace_root.join("models/local.toml");
+    println!("cargo:rerun-if-changed={}", local_toml.display());
 
-    let mut entries = Vec::new();
-    entries.extend(scrape_factory(&llm_factory, "ModelKind::Llm"));
-    entries.extend(scrape_factory(&vlm_factory, "ModelKind::Vlm"));
+    let entries = parse_local_toml(&local_toml);
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
     let mut code = String::from(
-        "/// Auto-generated from mlx-swift-lm's LLM + VLM model factories.\n\
-         /// Each entry: (alias, hf_repo_id, default_prompt, kind).\n\
-         pub const MODEL_REGISTRY: &[(&str, &str, &str, ModelKind)] = &[\n",
+        "/// Auto-generated from models/local.toml.\n\
+         /// Each entry: (alias, hf_repo_id, kind, size_mb).\n\
+         pub const MODEL_REGISTRY: &[(&str, &str, ModelKind, u64)] = &[\n",
     );
-    for (alias, id, prompt, kind) in &entries {
-        let escaped_prompt = prompt.replace('\\', "\\\\").replace('"', "\\\"");
+    for (alias, id, kind, size_mb) in &entries {
         code.push_str(&format!(
-            "    (\"{alias}\", \"{id}\", \"{escaped_prompt}\", {kind}),\n"
+            "    (\"{alias}\", \"{id}\", {kind}, {size_mb}),\n"
         ));
     }
     code.push_str("];\n");
@@ -315,12 +311,13 @@ fn generate_model_registry(mlx_dir: &Path) {
     fs::write(&registry_path, &code).expect("write model_registry.rs");
 }
 
-/// Scrape `ModelConfiguration(id: ..., defaultPrompt: ...)` declarations
-/// out of one `*ModelFactory.swift` file and tag each with `kind`.
-/// `kind` is emitted verbatim into the generated Rust source, so it
-/// must be a valid `ModelKind` variant expression (`"ModelKind::Llm"`
-/// or `"ModelKind::Vlm"`).
-fn scrape_factory(path: &Path, kind: &'static str) -> Vec<(String, String, String, &'static str)> {
+
+/// Parse `models/local.toml` into registry entries.
+///
+/// The TOML uses nested tables `[models.family.size.quant]` with fields
+/// `repo_id` and `size_mb`. This flattens them to
+/// `("family.size.quant", repo_id, ModelKind::Llm, size_mb)`.
+fn parse_local_toml(path: &Path) -> Vec<(String, String, &'static str, u64)> {
     let source = match fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -328,47 +325,43 @@ fn scrape_factory(path: &Path, kind: &'static str) -> Vec<(String, String, Strin
             return Vec::new();
         }
     };
-    println!("cargo:rerun-if-changed={}", path.display());
 
-    // Parse entries like:
-    //   static public let foo = ModelConfiguration(
-    //       id: "mlx-community/Some-Model-4bit",
-    //       defaultPrompt: "Hello"
-    //   )
+    let table: toml::Table = match source.parse() {
+        Ok(t) => t,
+        Err(e) => {
+            println!("cargo:warning=cannot parse {}: {e}", path.display());
+            return Vec::new();
+        }
+    };
+
+    let Some(toml::Value::Table(families)) = table.get("models") else {
+        return Vec::new();
+    };
+
     let mut entries = Vec::new();
-    let lines: Vec<&str> = source.lines().collect();
-    let mut i = 0;
-    while i < lines.len() {
-        let line = lines[i].trim();
-        if line.starts_with("static public let") && line.contains("ModelConfiguration(") {
-            let mut id = String::new();
-            let mut prompt = String::new();
-            // Scan the next few lines for id: and defaultPrompt:
-            for l in lines[i..std::cmp::min(i + 8, lines.len())]
-                .iter()
-                .map(|l| l.trim())
-            {
-                if let Some(rest) = l.strip_prefix("id: \"").and_then(|r| r.split('"').next()) {
-                    id = rest.to_string();
-                }
-                if let Some(rest) = l
-                    .strip_prefix("defaultPrompt: \"")
-                    .and_then(|r| r.rfind('"').map(|end| &r[..end]))
-                {
-                    prompt = rest.to_string();
-                }
-            }
-            if !id.is_empty() {
-                // Derive a short alias from the HF repo name:
-                // "mlx-community/Qwen3.5-2B-MLX-4bit" → "qwen3.5-2b-mlx-4bit"
-                let alias = id
-                    .strip_prefix("mlx-community/")
-                    .unwrap_or(&id)
-                    .to_lowercase();
-                entries.push((alias, id, prompt, kind));
+    for (family, sizes) in families {
+        let Some(sizes) = sizes.as_table() else {
+            continue;
+        };
+        for (size, quants) in sizes {
+            let Some(quants) = quants.as_table() else {
+                continue;
+            };
+            for (quant, entry) in quants {
+                let Some(entry) = entry.as_table() else {
+                    continue;
+                };
+                let Some(repo_id) = entry.get("repo_id").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let size_mb = entry
+                    .get("size_mb")
+                    .and_then(|v| v.as_integer())
+                    .unwrap_or(0) as u64;
+                let alias = format!("{family}.{size}.{quant}");
+                entries.push((alias, repo_id.to_string(), "ModelKind::Llm", size_mb));
             }
         }
-        i += 1;
     }
     entries
 }

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -22,7 +22,6 @@ use crabllm_core::{
 };
 use futures::{channel::mpsc, stream::StreamExt};
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -31,10 +30,6 @@ use std::{
 #[derive(Clone)]
 pub struct MlxProvider {
     pool: Arc<MlxPool>,
-    /// Extra model aliases (alias → HF repo ID) for models not in the
-    /// build-time static registry. Checked before the static registry
-    /// in all resolve calls.
-    extra_models: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for MlxProvider {
@@ -45,27 +40,13 @@ impl std::fmt::Debug for MlxProvider {
 
 impl MlxProvider {
     pub fn new(pool: Arc<MlxPool>) -> Self {
-        Self {
-            pool,
-            extra_models: HashMap::new(),
-        }
+        Self { pool }
     }
 
-    /// Create a provider with additional model aliases beyond the
-    /// build-time registry. Each entry maps a short alias to a full
-    /// HuggingFace repo ID (e.g. `"qwen3.5-0.6b"` → `"mlx-community/Qwen3.5-0.6B-MLX-4bit"`).
-    pub fn with_extra_models(pool: Arc<MlxPool>, extra_models: HashMap<String, String>) -> Self {
-        Self { pool, extra_models }
-    }
-
-    /// Resolve a model alias to a HF repo ID, checking extra models
-    /// first, then the static registry, then passing through as-is.
+    /// Resolve a model alias to a HF repo ID via the build-time
+    /// registry, passing through as-is if not found.
     fn resolve_repo_id<'a>(&'a self, model_id: &'a str) -> &'a str {
-        self.extra_models
-            .get(model_id)
-            .map(|s| s.as_str())
-            .or_else(|| crate::registry::resolve(model_id))
-            .unwrap_or(model_id)
+        crate::registry::resolve(model_id).unwrap_or(model_id)
     }
 
     /// Snapshot the pool's loaded-model inventory. See

--- a/crates/mlx/src/registry.rs
+++ b/crates/mlx/src/registry.rs
@@ -1,9 +1,8 @@
-//! Predefined model registry, auto-generated from mlx-swift-lm's
-//! `LLMModelFactory.swift` + `VLMModelFactory.swift` at build time.
+//! Predefined model registry, auto-generated from `models/local.toml`
+//! at build time.
 //!
-//! Each entry is a `(alias, hf_repo_id, default_prompt, kind)` tuple.
-//! The alias is a lowercase version of the HuggingFace model name
-//! (e.g. `"qwen3.5-2b-mlx-4bit"` for `mlx-community/Qwen3.5-2B-MLX-4bit`).
+//! Each entry is a `(alias, hf_repo_id, kind, size_mb)` tuple.
+//! The alias is `family.size.quant` (e.g. `"qwen3.5.2b.4bit"`).
 //!
 //! Use [`resolve`] to map an alias or full repo id to the canonical
 //! HF repo path. Use [`list`] to get all available models for UI
@@ -32,21 +31,21 @@ pub struct ModelEntry {
     pub alias: &'static str,
     /// Full HuggingFace repo id (e.g. `"mlx-community/Qwen3.5-2B-MLX-4bit"`).
     pub repo_id: &'static str,
-    /// Example prompt for the model.
-    pub default_prompt: &'static str,
     /// Whether the model is an LLM or a VLM.
     pub kind: ModelKind,
+    /// Approximate disk size in megabytes (0 = unknown).
+    pub size_mb: u64,
 }
 
 /// List all predefined models.
 pub fn list() -> Vec<ModelEntry> {
     MODEL_REGISTRY
         .iter()
-        .map(|&(alias, repo_id, default_prompt, kind)| ModelEntry {
+        .map(|&(alias, repo_id, kind, size_mb)| ModelEntry {
             alias,
             repo_id,
-            default_prompt,
             kind,
+            size_mb,
         })
         .collect()
 }
@@ -66,8 +65,8 @@ pub fn resolve(model: &str) -> Option<&'static str> {
         return Some(
             MODEL_REGISTRY
                 .iter()
-                .find(|(_, id, _, _)| *id == model)
-                .map(|(_, id, _, _)| *id)
+                .find(|(_, id, ..)| *id == model)
+                .map(|(_, id, ..)| *id)
                 .unwrap_or_else(|| {
                     // Not in registry but looks like a repo id — pass through.
                     // Leak is fine: this is called once per model load.
@@ -80,6 +79,6 @@ pub fn resolve(model: &str) -> Option<&'static str> {
     let lower = model.to_lowercase();
     MODEL_REGISTRY
         .iter()
-        .find(|(alias, _, _, _)| *alias == lower)
-        .map(|(_, id, _, _)| *id)
+        .find(|(alias, ..)| *alias == lower)
+        .map(|(_, id, ..)| *id)
 }

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -14,6 +14,7 @@ native-tls = ["crabllm-provider/native-tls"]
 rustls = ["crabllm-provider/rustls"]
 storage-redis = ["redis"]
 storage-sqlite = ["sqlx"]
+openapi = ["crabllm-core/openapi", "utoipa"]
 
 [dependencies]
 crabllm-core = { workspace = true, features = ["gateway"] }
@@ -37,6 +38,7 @@ uuid.workspace = true
 sha2.workspace = true
 rand.workspace = true
 metrics.workspace = true
+utoipa = { workspace = true, optional = true }
 
 # optional
 redis = { workspace = true, optional = true }

--- a/crates/proxy/src/admin.rs
+++ b/crates/proxy/src/admin.rs
@@ -1,3 +1,4 @@
+use crate::PREFIX_KEYS;
 use axum::{
     Json, Router,
     extract::{Path, Request, State},
@@ -6,14 +7,12 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use crabllm_core::{ApiError, KeyConfig, Prefix, Storage, storage_key};
+use crabllm_core::{ApiError, KeyConfig, KeyRateLimit, Storage, storage_key};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
-
-const KEY_PREFIX: Prefix = *b"keys";
 
 #[derive(Clone)]
 pub struct KeyAdminState {
@@ -41,13 +40,16 @@ pub fn key_admin_routes(
     };
     Router::new()
         .route("/v1/admin/keys", post(create_key).get(list_keys))
-        .route("/v1/admin/keys/{name}", get(get_key).delete(delete_key))
+        .route(
+            "/v1/admin/keys/{name}",
+            get(get_key).patch(update_key).delete(delete_key),
+        )
         .route_layer(middleware::from_fn_with_state(state.clone(), admin_auth))
         .with_state(state)
 }
 
 /// Timing-resistant token comparison. Leaks length but not content.
-pub(crate) fn constant_time_eq(a: &str, b: &str) -> bool {
+fn constant_time_eq(a: &str, b: &str) -> bool {
     if a.len() != b.len() {
         return false;
     }
@@ -58,36 +60,34 @@ pub(crate) fn constant_time_eq(a: &str, b: &str) -> bool {
     diff == 0
 }
 
-/// Admin auth middleware — validates Bearer token against admin_token.
-async fn admin_auth(State(state): State<KeyAdminState>, request: Request, next: Next) -> Response {
-    let auth_header = request
+/// Validate admin Bearer token from request headers.
+/// Returns `Ok(())` on success, `Err(Response)` with 401 on failure.
+#[allow(clippy::result_large_err)]
+pub(crate) fn check_admin_token(request: &Request, admin_token: &str) -> Result<(), Response> {
+    let token = request
         .headers()
         .get("authorization")
-        .and_then(|v| v.to_str().ok());
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "));
 
-    let token = match auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
-        Some(t) => t,
-        None => {
-            return err_response(
-                StatusCode::UNAUTHORIZED,
-                "missing or invalid Authorization header",
-                "authentication_error",
-            );
-        }
-    };
-
-    if !constant_time_eq(token, &state.admin_token) {
-        return err_response(
+    match token {
+        Some(t) if constant_time_eq(t, admin_token) => Ok(()),
+        _ => Err(err_response(
             StatusCode::UNAUTHORIZED,
-            "invalid admin token",
+            "missing or invalid admin token",
             "authentication_error",
-        );
+        )),
     }
+}
 
+async fn admin_auth(State(state): State<KeyAdminState>, request: Request, next: Next) -> Response {
+    if let Err(r) = check_admin_token(&request, &state.admin_token) {
+        return r;
+    }
     next.run(request).await
 }
 
-fn err_response(status: StatusCode, message: &str, error_type: &str) -> Response {
+pub(crate) fn err_response(status: StatusCode, message: &str, error_type: &str) -> Response {
     (status, Json(ApiError::new(message, error_type))).into_response()
 }
 
@@ -96,6 +96,8 @@ struct CreateKeyRequest {
     name: String,
     #[serde(default = "default_models")]
     models: Vec<String>,
+    #[serde(default)]
+    rate_limit: Option<KeyRateLimit>,
 }
 
 fn default_models() -> Vec<String> {
@@ -107,6 +109,8 @@ struct KeyResponse {
     name: String,
     key: String,
     models: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit: Option<KeyRateLimit>,
 }
 
 #[derive(Serialize)]
@@ -114,6 +118,8 @@ struct KeySummary {
     name: String,
     key_prefix: String,
     models: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rate_limit: Option<KeyRateLimit>,
     source: &'static str,
 }
 
@@ -157,7 +163,7 @@ async fn create_key(
 
     // Check storage for existing name (storage is keyed by name, the
     // authoritative source for dynamic keys).
-    let skey = storage_key(&KEY_PREFIX, body.name.as_bytes());
+    let skey = storage_key(&PREFIX_KEYS, body.name.as_bytes());
     match state.storage.get(&skey).await {
         Ok(Some(_)) => {
             return err_response(
@@ -181,6 +187,7 @@ async fn create_key(
         name: body.name.clone(),
         key: key.clone(),
         models: body.models.clone(),
+        rate_limit: body.rate_limit.clone(),
     };
 
     // Storage-first: persist before updating key_map.
@@ -215,6 +222,7 @@ async fn create_key(
             name: body.name,
             key,
             models: body.models,
+            rate_limit: body.rate_limit,
         }),
     )
         .into_response()
@@ -229,11 +237,12 @@ async fn list_keys(State(state): State<KeyAdminState>) -> Response {
             name: kc.name.clone(),
             key_prefix: mask_key(&kc.key),
             models: kc.models.clone(),
+            rate_limit: kc.rate_limit.clone(),
             source: "config",
         })
         .collect();
 
-    let pairs = match state.storage.list(&KEY_PREFIX).await {
+    let pairs = match state.storage.list(&PREFIX_KEYS).await {
         Ok(p) => p,
         Err(e) => {
             return err_response(
@@ -254,6 +263,7 @@ async fn list_keys(State(state): State<KeyAdminState>) -> Response {
                 name: kc.name,
                 key_prefix: mask_key(&kc.key),
                 models: kc.models,
+                rate_limit: kc.rate_limit,
                 source: "dynamic",
             });
         }
@@ -270,18 +280,20 @@ async fn get_key(State(state): State<KeyAdminState>, Path(name): Path<String>) -
             name: kc.name.clone(),
             key_prefix: mask_key(&kc.key),
             models: kc.models.clone(),
+            rate_limit: kc.rate_limit.clone(),
             source: "config",
         })
         .into_response();
     }
 
-    let skey = storage_key(&KEY_PREFIX, name.as_bytes());
+    let skey = storage_key(&PREFIX_KEYS, name.as_bytes());
     match state.storage.get(&skey).await {
         Ok(Some(bytes)) => match serde_json::from_slice::<KeyConfig>(&bytes) {
             Ok(kc) => Json(KeySummary {
                 name: kc.name,
                 key_prefix: mask_key(&kc.key),
                 models: kc.models,
+                rate_limit: kc.rate_limit,
                 source: "dynamic",
             })
             .into_response(),
@@ -304,6 +316,119 @@ async fn get_key(State(state): State<KeyAdminState>, Path(name): Path<String>) -
     }
 }
 
+/// PATCH /v1/admin/keys/:name — partial update of a dynamic key.
+///
+/// JSON Merge Patch semantics: present fields are set, absent fields
+/// are unchanged, `null` clears the field. The `name` and `key` fields
+/// are immutable (not accepted in the patch body).
+async fn update_key(
+    State(state): State<KeyAdminState>,
+    Path(name): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Response {
+    if state.toml_key_names.contains(&name) {
+        return err_response(
+            StatusCode::FORBIDDEN,
+            &format!("key '{name}' is managed by config file and cannot be updated via API"),
+            "invalid_request_error",
+        );
+    }
+
+    let skey = storage_key(&PREFIX_KEYS, name.as_bytes());
+
+    // Load the existing config from storage.
+    let mut config = match state.storage.get(&skey).await {
+        Ok(Some(bytes)) => match serde_json::from_slice::<KeyConfig>(&bytes) {
+            Ok(kc) => kc,
+            Err(_) => {
+                return err_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "corrupt key data",
+                    "server_error",
+                );
+            }
+        },
+        Ok(None) => {
+            return err_response(
+                StatusCode::NOT_FOUND,
+                &format!("key '{name}' not found"),
+                "invalid_request_error",
+            );
+        }
+        Err(e) => {
+            return err_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &e.to_string(),
+                "server_error",
+            );
+        }
+    };
+
+    // Reject immutable fields.
+    if body.get("name").is_some() || body.get("key").is_some() {
+        return err_response(
+            StatusCode::BAD_REQUEST,
+            "'name' and 'key' are immutable and cannot be patched",
+            "invalid_request_error",
+        );
+    }
+
+    // Apply patch fields.
+    if let Some(models) = body.get("models") {
+        match serde_json::from_value::<Vec<String>>(models.clone()) {
+            Ok(m) => config.models = m,
+            Err(e) => {
+                return err_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("invalid 'models': {e}"),
+                    "invalid_request_error",
+                );
+            }
+        }
+    }
+
+    if body.get("rate_limit").is_some() {
+        match serde_json::from_value::<Option<KeyRateLimit>>(body["rate_limit"].clone()) {
+            Ok(rl) => config.rate_limit = rl,
+            Err(e) => {
+                return err_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("invalid 'rate_limit': {e}"),
+                    "invalid_request_error",
+                );
+            }
+        }
+    }
+
+    // Persist updated config.
+    let value = match serde_json::to_vec(&config) {
+        Ok(v) => v,
+        Err(e) => {
+            return err_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &e.to_string(),
+                "server_error",
+            );
+        }
+    };
+    if let Err(e) = state.storage.set(&skey, value).await {
+        return err_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &e.to_string(),
+            "server_error",
+        );
+    }
+
+    Json(KeySummary {
+        name: config.name,
+        key_prefix: mask_key(&config.key),
+        models: config.models,
+        rate_limit: config.rate_limit,
+        source: "dynamic",
+    })
+    .into_response()
+}
+
 /// DELETE /v1/admin/keys/:name — revoke a virtual key.
 async fn delete_key(State(state): State<KeyAdminState>, Path(name): Path<String>) -> Response {
     // TOML-managed keys cannot be deleted via the API.
@@ -315,7 +440,7 @@ async fn delete_key(State(state): State<KeyAdminState>, Path(name): Path<String>
         );
     }
 
-    let skey = storage_key(&KEY_PREFIX, name.as_bytes());
+    let skey = storage_key(&PREFIX_KEYS, name.as_bytes());
 
     // Load the key to find the token for key_map removal.
     let token = match state.storage.get(&skey).await {
@@ -370,7 +495,7 @@ pub async fn load_stored_keys(
     toml_keys: &[KeyConfig],
     key_map: &RwLock<HashMap<String, String>>,
 ) {
-    let pairs = match storage.list(&KEY_PREFIX).await {
+    let pairs = match storage.list(&PREFIX_KEYS).await {
         Ok(p) => p,
         Err(e) => {
             eprintln!("warning: failed to load stored keys: {e}");

--- a/crates/proxy/src/admin_models.rs
+++ b/crates/proxy/src/admin_models.rs
@@ -1,3 +1,4 @@
+use crate::PREFIX_MODELS;
 use axum::{
     Json, Router,
     extract::{Path, Request, State},
@@ -6,17 +7,13 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post, put},
 };
-use crabllm_core::{
-    ApiError, GatewayConfig, ModelInfo, Prefix, Storage, resolve_model_info_full, storage_key,
-};
+use crabllm_core::{GatewayConfig, ModelInfo, Storage, resolve_model_info_full, storage_key};
 use serde::Serialize;
 use std::{
     collections::HashMap,
     path::PathBuf,
     sync::{Arc, RwLock},
 };
-
-const MODEL_PREFIX: Prefix = *b"modl";
 
 #[derive(Clone)]
 struct ModelAdminState {
@@ -58,24 +55,14 @@ async fn admin_auth(
     request: Request,
     next: Next,
 ) -> Response {
-    let token = request
-        .headers()
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|h| h.strip_prefix("Bearer "));
-
-    match token {
-        Some(t) if crate::admin::constant_time_eq(t, &state.admin_token) => next.run(request).await,
-        _ => err_response(
-            StatusCode::UNAUTHORIZED,
-            "missing or invalid admin token",
-            "authentication_error",
-        ),
+    if let Err(r) = crate::admin::check_admin_token(&request, &state.admin_token) {
+        return r;
     }
+    next.run(request).await
 }
 
 fn err_response(status: StatusCode, message: &str, error_type: &str) -> Response {
-    (status, Json(ApiError::new(message, error_type))).into_response()
+    crate::admin::err_response(status, message, error_type)
 }
 
 #[derive(Serialize)]
@@ -174,7 +161,7 @@ async fn upsert_model(
     Json(info): Json<ModelInfo>,
 ) -> Response {
     // Persist to storage first.
-    let skey = storage_key(&MODEL_PREFIX, model.as_bytes());
+    let skey = storage_key(&PREFIX_MODELS, model.as_bytes());
     let value = match serde_json::to_vec(&info) {
         Ok(v) => v,
         Err(e) => {
@@ -240,7 +227,7 @@ async fn delete_model(State(state): State<ModelAdminState>, Path(model): Path<St
     }
 
     // Storage-first: delete from storage before updating in-memory map.
-    let skey = storage_key(&MODEL_PREFIX, model.as_bytes());
+    let skey = storage_key(&PREFIX_MODELS, model.as_bytes());
     if let Err(e) = state.storage.delete(&skey).await {
         return err_response(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -334,7 +321,7 @@ async fn flush_models(State(state): State<ModelAdminState>) -> Response {
         .clear();
 
     for model in admin_map.keys() {
-        let skey = storage_key(&MODEL_PREFIX, model.as_bytes());
+        let skey = storage_key(&PREFIX_MODELS, model.as_bytes());
         let _ = state.storage.delete(&skey).await;
     }
 
@@ -356,7 +343,7 @@ pub async fn load_stored_models(
     storage: &dyn Storage,
     overrides: &RwLock<HashMap<String, ModelInfo>>,
 ) {
-    let pairs = match storage.list(&MODEL_PREFIX).await {
+    let pairs = match storage.list(&PREFIX_MODELS).await {
         Ok(p) => p,
         Err(e) => {
             eprintln!("warning: failed to load stored model overrides: {e}");

--- a/crates/proxy/src/admin_providers.rs
+++ b/crates/proxy/src/admin_providers.rs
@@ -7,7 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::post,
 };
-use crabllm_core::{ApiError, Error, GatewayConfig, Provider};
+use crabllm_core::{Error, GatewayConfig, Provider};
 use crabllm_provider::ProviderRegistry;
 use serde::Serialize;
 use std::{path::PathBuf, sync::Arc};
@@ -63,23 +63,10 @@ async fn admin_auth<P: Provider>(
     request: Request,
     next: Next,
 ) -> Response {
-    let token = request
-        .headers()
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|h| h.strip_prefix("Bearer "));
-
-    match token {
-        Some(t) if crate::admin::constant_time_eq(t, &state.admin_token) => next.run(request).await,
-        _ => (
-            StatusCode::UNAUTHORIZED,
-            Json(ApiError::new(
-                "missing or invalid admin token",
-                "authentication_error",
-            )),
-        )
-            .into_response(),
+    if let Err(r) = crate::admin::check_admin_token(&request, &state.admin_token) {
+        return r;
     }
+    next.run(request).await
 }
 
 #[derive(Serialize)]
@@ -95,42 +82,33 @@ async fn reload_providers<P: Provider>(State(state): State<ProviderAdminState<P>
     let raw = match tokio::fs::read_to_string(&state.config_path).await {
         Ok(s) => s,
         Err(e) => {
-            return (
+            return crate::admin::err_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiError::new(
-                    format!("failed to read config file: {e}"),
-                    "server_error",
-                )),
-            )
-                .into_response();
+                &format!("failed to read config file: {e}"),
+                "server_error",
+            );
         }
     };
 
     let config: GatewayConfig = match toml::from_str(&raw) {
         Ok(c) => c,
         Err(e) => {
-            return (
+            return crate::admin::err_response(
                 StatusCode::BAD_REQUEST,
-                Json(ApiError::new(
-                    format!("failed to parse config: {e}"),
-                    "invalid_request_error",
-                )),
-            )
-                .into_response();
+                &format!("failed to parse config: {e}"),
+                "invalid_request_error",
+            );
         }
     };
 
     let new_registry = match (state.rebuilder)(&config) {
         Ok(r) => r,
         Err(e) => {
-            return (
+            return crate::admin::err_response(
                 StatusCode::BAD_REQUEST,
-                Json(ApiError::new(
-                    format!("failed to build registry: {e}"),
-                    "invalid_request_error",
-                )),
-            )
-                .into_response();
+                &format!("failed to build registry: {e}"),
+                "invalid_request_error",
+            );
         }
     };
 

--- a/crates/proxy/src/ext/audit.rs
+++ b/crates/proxy/src/ext/audit.rs
@@ -1,3 +1,4 @@
+use crate::PREFIX_AUDIT;
 use axum::{
     Json, Router,
     extract::{Query, State},
@@ -7,12 +8,10 @@ use axum::{
 };
 use crabllm_core::{
     ApiError, BoxFuture, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Error,
-    ModelInfo, Prefix, RequestContext, Storage, resolve_model_info_full, storage_key,
+    ModelInfo, RequestContext, Storage, resolve_model_info_full, storage_key,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
-
-const PREFIX: Prefix = *b"alog";
 
 pub struct AuditLogger {
     storage: Arc<dyn Storage>,
@@ -57,7 +56,7 @@ impl AuditLogger {
         let mut suffix = Vec::with_capacity(8 + record.request_id.len());
         suffix.extend_from_slice(&ts_bytes);
         suffix.extend_from_slice(record.request_id.as_bytes());
-        let key = storage_key(&PREFIX, &suffix);
+        let key = storage_key(&PREFIX_AUDIT, &suffix);
 
         let storage = self.storage.clone();
         // Fire-and-forget — audit logging must not block the response path.
@@ -94,8 +93,8 @@ impl crabllm_core::Extension for AuditLogger {
         "audit"
     }
 
-    fn prefix(&self) -> Prefix {
-        PREFIX
+    fn prefix(&self) -> crabllm_core::Prefix {
+        PREFIX_AUDIT
     }
 
     fn on_response(
@@ -222,7 +221,7 @@ async fn logs_handler(
     State(storage): State<Arc<dyn Storage>>,
     Query(query): Query<LogQuery>,
 ) -> Response {
-    let pairs = match storage.list(&PREFIX).await {
+    let pairs = match storage.list(&PREFIX_AUDIT).await {
         Ok(p) => p,
         Err(e) => {
             return (

--- a/crates/proxy/src/ext/budget.rs
+++ b/crates/proxy/src/ext/budget.rs
@@ -1,7 +1,8 @@
+use crate::PREFIX_BUDGET;
 use axum::{Json, Router, routing::get};
 use crabllm_core::{
     BoxFuture, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ExtensionError,
-    ModelInfo, Prefix, RequestContext, Storage, resolve_model_info_full, storage_key,
+    ModelInfo, RequestContext, Storage, resolve_model_info_full, storage_key,
 };
 use serde::Serialize;
 use std::{collections::HashMap, sync::Arc};
@@ -15,8 +16,6 @@ pub struct Budget {
 }
 
 impl Budget {
-    const PREFIX: Prefix = *b"bdgt";
-
     pub fn new(
         config: &serde_json::Value,
         storage: Arc<dyn Storage>,
@@ -86,7 +85,7 @@ impl Budget {
 
     pub fn admin_routes(&self) -> Router {
         let storage = self.storage.clone();
-        let prefix = Self::PREFIX;
+        let prefix = PREFIX_BUDGET;
         let default_budget = self.default_budget_micros;
         let key_budgets = self.key_budgets.clone();
 
@@ -110,7 +109,7 @@ impl Budget {
     ) {
         let micros = self.cost_micros(model, provider, prompt, completion);
         if micros > 0 {
-            let key = storage_key(&Self::PREFIX, key_name.as_bytes());
+            let key = storage_key(&PREFIX_BUDGET, key_name.as_bytes());
             let _ = self.storage.increment(&key, micros).await;
         }
     }
@@ -121,8 +120,8 @@ impl crabllm_core::Extension for Budget {
         "budget"
     }
 
-    fn prefix(&self) -> Prefix {
-        Self::PREFIX
+    fn prefix(&self) -> crabllm_core::Prefix {
+        PREFIX_BUDGET
     }
 
     fn on_request(&self, ctx: &RequestContext) -> BoxFuture<'_, Result<(), ExtensionError>> {
@@ -133,7 +132,7 @@ impl crabllm_core::Extension for Budget {
         let budget = self.budget_for_key(&key_name);
 
         Box::pin(async move {
-            let key = storage_key(&Self::PREFIX, key_name.as_bytes());
+            let key = storage_key(&PREFIX_BUDGET, key_name.as_bytes());
             let spent = self.storage.increment(&key, 0).await.unwrap_or(0);
 
             if spent >= budget {
@@ -210,7 +209,7 @@ struct BudgetEntry {
 
 async fn budget_handler(
     storage: Arc<dyn Storage>,
-    prefix: Prefix,
+    prefix: crabllm_core::Prefix,
     default_budget_micros: i64,
     key_budgets: HashMap<String, i64>,
 ) -> Json<Vec<BudgetEntry>> {

--- a/crates/proxy/src/ext/cache.rs
+++ b/crates/proxy/src/ext/cache.rs
@@ -1,7 +1,7 @@
+use crate::PREFIX_CACHE;
 use axum::{Router, http::StatusCode, routing::delete};
 use crabllm_core::{
-    BoxFuture, ChatCompletionRequest, ChatCompletionResponse, Prefix, RequestContext, Storage,
-    storage_key,
+    BoxFuture, ChatCompletionRequest, ChatCompletionResponse, RequestContext, Storage, storage_key,
 };
 use sha2::{Digest, Sha256};
 use std::{
@@ -28,8 +28,6 @@ pub struct Cache {
 }
 
 impl Cache {
-    const PREFIX: Prefix = *b"cach";
-
     pub fn new(config: &serde_json::Value, storage: Arc<dyn Storage>) -> Result<Self, String> {
         let ttl_seconds = config
             .get("ttl_seconds")
@@ -46,7 +44,7 @@ impl Cache {
         let mut hasher = Sha256::new();
         // Write JSON directly into the hasher — no intermediate String allocation.
         let _ = serde_json::to_writer(DigestWriter(&mut hasher), request);
-        storage_key(&Self::PREFIX, &hasher.finalize())
+        storage_key(&PREFIX_CACHE, &hasher.finalize())
     }
 
     fn now_secs() -> u64 {
@@ -58,7 +56,7 @@ impl Cache {
 
     pub fn admin_routes(&self) -> Router {
         let storage = self.storage.clone();
-        let prefix = Self::PREFIX;
+        let prefix = PREFIX_CACHE;
         Router::new().route(
             "/v1/cache",
             delete(move || {
@@ -80,8 +78,8 @@ impl crabllm_core::Extension for Cache {
         "cache"
     }
 
-    fn prefix(&self) -> Prefix {
-        Self::PREFIX
+    fn prefix(&self) -> crabllm_core::Prefix {
+        PREFIX_CACHE
     }
 
     fn on_cache_lookup(

--- a/crates/proxy/src/ext/rate_limit.rs
+++ b/crates/proxy/src/ext/rate_limit.rs
@@ -1,6 +1,7 @@
+use crate::{PREFIX_KEYS, PREFIX_RATE_LIMIT};
 use crabllm_core::{
     BoxFuture, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ExtensionError,
-    Prefix, RequestContext, Storage,
+    KeyConfig, KeyRateLimit, RequestContext, Storage, storage_key,
 };
 use std::{
     sync::Arc,
@@ -42,6 +43,36 @@ impl RateLimit {
             tokens_per_minute: tpm,
         })
     }
+
+    /// Look up per-key rate limit from storage. Returns the per-key
+    /// override merged with global defaults, or the global defaults
+    /// if the key has no override.
+    async fn limits_for(&self, key_name: &str) -> (u64, Option<u64>) {
+        if key_name == "__global" {
+            return (self.requests_per_minute, self.tokens_per_minute);
+        }
+
+        let skey = storage_key(&PREFIX_KEYS, key_name.as_bytes());
+        let rl = self
+            .storage
+            .get(&skey)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|bytes| serde_json::from_slice::<KeyConfig>(&bytes).ok())
+            .and_then(|kc| kc.rate_limit);
+
+        match rl {
+            Some(KeyRateLimit {
+                requests_per_minute,
+                tokens_per_minute,
+            }) => (
+                requests_per_minute.unwrap_or(self.requests_per_minute),
+                tokens_per_minute.or(self.tokens_per_minute),
+            ),
+            None => (self.requests_per_minute, self.tokens_per_minute),
+        }
+    }
 }
 
 fn current_minute() -> u64 {
@@ -57,26 +88,20 @@ impl crabllm_core::Extension for RateLimit {
         "rate_limit"
     }
 
-    fn prefix(&self) -> Prefix {
-        *b"rlim"
+    fn prefix(&self) -> crabllm_core::Prefix {
+        PREFIX_RATE_LIMIT
     }
 
     fn on_request(&self, ctx: &RequestContext) -> BoxFuture<'_, Result<(), ExtensionError>> {
-        let key_name = ctx.key_name.as_deref().unwrap_or("__global");
-        let minute = current_minute();
-
-        let rpm_suffix = format!("{key_name}:{minute}");
-        let rpm_key = self.storage_key(rpm_suffix.as_bytes());
-        let rpm_limit = self.requests_per_minute;
-
-        let tpm_limit = self.tokens_per_minute;
-        let tpm_key = tpm_limit.map(|_| {
-            let tpm_suffix = format!("{key_name}:tpm:{minute}");
-            self.storage_key(tpm_suffix.as_bytes())
-        });
+        let key_name = ctx.key_name.as_deref().unwrap_or("__global").to_string();
 
         Box::pin(async move {
+            let (rpm_limit, tpm_limit) = self.limits_for(&key_name).await;
+            let minute = current_minute();
+
             // Check RPM.
+            let rpm_suffix = format!("{key_name}:{minute}");
+            let rpm_key = self.storage_key(rpm_suffix.as_bytes());
             let count = self
                 .storage
                 .increment(&rpm_key, 1)
@@ -92,10 +117,12 @@ impl crabllm_core::Extension for RateLimit {
             }
 
             // Check TPM.
-            if let (Some(limit), Some(key)) = (tpm_limit, &tpm_key) {
+            if let Some(limit) = tpm_limit {
+                let tpm_suffix = format!("{key_name}:tpm:{minute}");
+                let tpm_key = self.storage_key(tpm_suffix.as_bytes());
                 let tokens = self
                     .storage
-                    .increment(key, 0)
+                    .increment(&tpm_key, 0)
                     .await
                     .map_err(|e| ExtensionError::new(500, e.to_string(), "server_error"))?;
 
@@ -118,10 +145,6 @@ impl crabllm_core::Extension for RateLimit {
         _request: &ChatCompletionRequest,
         response: &ChatCompletionResponse,
     ) -> BoxFuture<'_, ()> {
-        if self.tokens_per_minute.is_none() {
-            return Box::pin(async {});
-        }
-
         let total_tokens = response
             .usage
             .as_ref()
@@ -132,6 +155,9 @@ impl crabllm_core::Extension for RateLimit {
             return Box::pin(async {});
         }
 
+        // Always record TPM — per-key overrides may enable TPM even when
+        // the global config has no tokens_per_minute. The actual limit
+        // check happens in on_request(); here we just track the counter.
         let key_name = ctx.key_name.as_deref().unwrap_or("__global");
         let minute = current_minute();
         let tpm_suffix = format!("{key_name}:tpm:{minute}");
@@ -143,10 +169,6 @@ impl crabllm_core::Extension for RateLimit {
     }
 
     fn on_chunk(&self, ctx: &RequestContext, chunk: &ChatCompletionChunk) -> BoxFuture<'_, ()> {
-        if self.tokens_per_minute.is_none() {
-            return Box::pin(async {});
-        }
-
         let total_tokens = chunk
             .usage
             .as_ref()

--- a/crates/proxy/src/ext/usage.rs
+++ b/crates/proxy/src/ext/usage.rs
@@ -1,9 +1,10 @@
-use axum::{Json, Router, routing::get};
+use crate::PREFIX_USAGE;
+use axum::{Json, Router, extract::Query, routing::get};
 use crabllm_core::{
-    BoxFuture, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Prefix,
-    RequestContext, Storage, storage_key,
+    BoxFuture, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, RequestContext,
+    Storage, storage_key,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 pub struct UsageTracker {
@@ -15,17 +16,13 @@ impl UsageTracker {
         Ok(Self { storage })
     }
 
-    /// The fixed prefix for this extension.
-    const PREFIX: Prefix = *b"usge";
-
     pub fn admin_routes(&self) -> Router {
         let storage = self.storage.clone();
-        let prefix = Self::PREFIX;
         Router::new().route(
             "/v1/usage",
-            get(move || {
+            get(move |query: Query<UsageQuery>| {
                 let storage = storage.clone();
-                async move { usage_handler(storage, prefix).await }
+                async move { usage_handler(storage, query.0).await }
             }),
         )
     }
@@ -44,14 +41,14 @@ impl UsageTracker {
         let _ = self
             .storage
             .increment(
-                &storage_key(&Self::PREFIX, prompt_suffix.as_bytes()),
+                &storage_key(&PREFIX_USAGE, prompt_suffix.as_bytes()),
                 prompt_tokens as i64,
             )
             .await;
         let _ = self
             .storage
             .increment(
-                &storage_key(&Self::PREFIX, completion_suffix.as_bytes()),
+                &storage_key(&PREFIX_USAGE, completion_suffix.as_bytes()),
                 completion_tokens as i64,
             )
             .await;
@@ -63,8 +60,8 @@ impl crabllm_core::Extension for UsageTracker {
         "usage"
     }
 
-    fn prefix(&self) -> Prefix {
-        Self::PREFIX
+    fn prefix(&self) -> crabllm_core::Prefix {
+        PREFIX_USAGE
     }
 
     fn on_response(
@@ -105,6 +102,12 @@ impl crabllm_core::Extension for UsageTracker {
     }
 }
 
+#[derive(Deserialize)]
+struct UsageQuery {
+    key: Option<String>,
+    model: Option<String>,
+}
+
 #[derive(Serialize)]
 struct UsageEntry {
     key: String,
@@ -113,8 +116,8 @@ struct UsageEntry {
     completion_tokens: i64,
 }
 
-async fn usage_handler(storage: Arc<dyn Storage>, prefix: Prefix) -> Json<Vec<UsageEntry>> {
-    let pairs = storage.list(&prefix).await.unwrap_or_default();
+async fn usage_handler(storage: Arc<dyn Storage>, query: UsageQuery) -> Json<Vec<UsageEntry>> {
+    let pairs = storage.list(&PREFIX_USAGE).await.unwrap_or_default();
 
     // Group by (key, model) — keys are PREFIX + "{key_name}:{model}:{p|c}"
     let mut entries: std::collections::HashMap<(String, String), (i64, i64)> =
@@ -135,6 +138,18 @@ async fn usage_handler(storage: Arc<dyn Storage>, prefix: Prefix) -> Json<Vec<Us
         let Some((key_name, model)) = rest.split_once(':') else {
             continue;
         };
+
+        // Apply filters.
+        if let Some(ref filter) = query.key
+            && key_name != filter
+        {
+            continue;
+        }
+        if let Some(ref filter) = query.model
+            && model != filter
+        {
+            continue;
+        }
 
         // Parse the counter value directly from the list() result bytes.
         let val = raw_value

--- a/crates/proxy/src/ext/usage.rs
+++ b/crates/proxy/src/ext/usage.rs
@@ -16,13 +16,14 @@ impl UsageTracker {
         Ok(Self { storage })
     }
 
+    /// Admin usage routes: `GET /v1/admin/usage?name=&model=` — global view.
     pub fn admin_routes(&self) -> Router {
         let storage = self.storage.clone();
         Router::new().route(
-            "/v1/usage",
-            get(move |query: Query<UsageQuery>| {
+            "/v1/admin/usage",
+            get(move |query: Query<AdminUsageQuery>| {
                 let storage = storage.clone();
-                async move { usage_handler(storage, query.0).await }
+                async move { admin_usage_handler(storage, query.0).await }
             }),
         )
     }
@@ -103,35 +104,42 @@ impl crabllm_core::Extension for UsageTracker {
 }
 
 #[derive(Deserialize)]
-struct UsageQuery {
-    key: Option<String>,
+struct AdminUsageQuery {
+    name: Option<String>,
     model: Option<String>,
 }
 
+#[derive(Deserialize)]
+pub struct UserUsageQuery {
+    pub model: Option<String>,
+}
+
 #[derive(Serialize)]
-struct UsageEntry {
-    key: String,
+pub struct UsageEntry {
+    name: String,
     model: String,
     prompt_tokens: i64,
     completion_tokens: i64,
 }
 
-async fn usage_handler(storage: Arc<dyn Storage>, query: UsageQuery) -> Json<Vec<UsageEntry>> {
+/// Query usage data from storage, filtered by optional key name and model.
+pub async fn query_usage(
+    storage: &dyn Storage,
+    name_filter: Option<&str>,
+    model_filter: Option<&str>,
+) -> Json<Vec<UsageEntry>> {
     let pairs = storage.list(&PREFIX_USAGE).await.unwrap_or_default();
 
-    // Group by (key, model) — keys are PREFIX + "{key_name}:{model}:{p|c}"
     let mut entries: std::collections::HashMap<(String, String), (i64, i64)> =
         std::collections::HashMap::new();
 
     for (raw_key, raw_value) in &pairs {
-        // Skip the prefix bytes, parse the suffix as UTF-8.
         let suffix = match std::str::from_utf8(&raw_key[crabllm_core::PREFIX_LEN..]) {
             Ok(s) => s,
             Err(_) => continue,
         };
 
         // suffix format: "{key_name}:{model}:{p|c}"
-        // Split from the right to handle key names or models containing ":"
         let Some((rest, kind)) = suffix.rsplit_once(':') else {
             continue;
         };
@@ -139,19 +147,17 @@ async fn usage_handler(storage: Arc<dyn Storage>, query: UsageQuery) -> Json<Vec
             continue;
         };
 
-        // Apply filters.
-        if let Some(ref filter) = query.key
+        if let Some(filter) = name_filter
             && key_name != filter
         {
             continue;
         }
-        if let Some(ref filter) = query.model
+        if let Some(filter) = model_filter
             && model != filter
         {
             continue;
         }
 
-        // Parse the counter value directly from the list() result bytes.
         let val = raw_value
             .get(..8)
             .and_then(|b| b.try_into().ok())
@@ -171,8 +177,8 @@ async fn usage_handler(storage: Arc<dyn Storage>, query: UsageQuery) -> Json<Vec
 
     let result: Vec<UsageEntry> = entries
         .into_iter()
-        .map(|((key, model), (prompt, completion))| UsageEntry {
-            key,
+        .map(|((name, model), (prompt, completion))| UsageEntry {
+            name,
             model,
             prompt_tokens: prompt,
             completion_tokens: completion,
@@ -180,4 +186,11 @@ async fn usage_handler(storage: Arc<dyn Storage>, query: UsageQuery) -> Json<Vec
         .collect();
 
     Json(result)
+}
+
+async fn admin_usage_handler(
+    storage: Arc<dyn Storage>,
+    query: AdminUsageQuery,
+) -> Json<Vec<UsageEntry>> {
+    query_usage(&*storage, query.name.as_deref(), query.model.as_deref()).await
 }

--- a/crates/proxy/src/handlers.rs
+++ b/crates/proxy/src/handlers.rs
@@ -89,6 +89,21 @@ pub(crate) fn emit_usage<S: Storage, P: Provider>(
     });
 }
 
+/// GET /v1/usage — user-facing, auto-scoped to the caller's key.
+pub(crate) async fn usage<S: Storage + 'static, P: Provider + 'static>(
+    State(state): State<AppState<S, P>>,
+    Extension(KeyName(key_name)): Extension<KeyName>,
+    query: axum::extract::Query<crate::ext::usage::UserUsageQuery>,
+) -> Json<Vec<crate::ext::usage::UsageEntry>> {
+    let name = key_name.as_deref().unwrap_or("__global");
+    crate::ext::usage::query_usage(
+        state.storage.as_ref() as &dyn Storage,
+        Some(name),
+        query.model.as_deref(),
+    )
+    .await
+}
+
 fn http_status_from_error(e: &crabllm_core::Error) -> u16 {
     match e {
         crabllm_core::Error::Provider { status, .. } => *status,

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -5,10 +5,20 @@ use axum::{
     response::Response,
     routing::{get, post},
 };
-use crabllm_core::{Provider, Storage};
+use crabllm_core::{Prefix, Provider, Storage};
 
 pub use auth::KeyName;
 pub use state::{AppState, UsageEvent};
+
+// Storage table prefixes. Each 4-byte prefix namespaces a logical table
+// in the key-value storage backend.
+pub const PREFIX_KEYS: Prefix = *b"keys";
+pub const PREFIX_MODELS: Prefix = *b"modl";
+pub const PREFIX_RATE_LIMIT: Prefix = *b"rlim";
+pub const PREFIX_USAGE: Prefix = *b"usge";
+pub const PREFIX_CACHE: Prefix = *b"cach";
+pub const PREFIX_BUDGET: Prefix = *b"bdgt";
+pub const PREFIX_AUDIT: Prefix = *b"alog";
 
 pub mod admin;
 pub mod admin_models;

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -63,6 +63,7 @@ where
             post(handlers::audio_transcriptions::<S, P>),
         )
         .route("/v1/models", get(handlers::models::<S, P>))
+        .route("/v1/usage", get(handlers::usage::<S, P>))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth::<S, P>,

--- a/crates/proxy/src/lib.rs
+++ b/crates/proxy/src/lib.rs
@@ -27,6 +27,8 @@ pub mod anthropic;
 pub mod auth;
 pub mod ext;
 pub(crate) mod handlers;
+#[cfg(feature = "openapi")]
+pub mod openapi;
 mod state;
 pub mod storage;
 

--- a/crates/proxy/src/openapi.rs
+++ b/crates/proxy/src/openapi.rs
@@ -1,0 +1,173 @@
+use utoipa::openapi::{
+    ComponentsBuilder, HttpMethod, InfoBuilder, PathItem, PathsBuilder,
+    path::{OperationBuilder, ParameterBuilder, ParameterIn},
+    security::{HttpAuthScheme, HttpBuilder, SecurityRequirement, SecurityScheme},
+};
+
+fn op(summary: &str) -> OperationBuilder {
+    OperationBuilder::new().summary(Some(summary))
+}
+
+/// Build a PathItem with multiple HTTP methods.
+fn multi(ops: &[(HttpMethod, &str)]) -> PathItem {
+    let mut item = PathItem::default();
+    for (method, summary) in ops {
+        let operation = op(summary).build();
+        match method {
+            HttpMethod::Get => item.get = Some(operation),
+            HttpMethod::Post => item.post = Some(operation),
+            HttpMethod::Put => item.put = Some(operation),
+            HttpMethod::Patch => item.patch = Some(operation),
+            HttpMethod::Delete => item.delete = Some(operation),
+            _ => {}
+        }
+    }
+    item
+}
+
+fn query(name: &str) -> ParameterBuilder {
+    ParameterBuilder::new()
+        .name(name)
+        .parameter_in(ParameterIn::Query)
+}
+
+pub fn spec() -> utoipa::openapi::OpenApi {
+    let paths = PathsBuilder::new()
+        // ── User-facing API ──
+        .path(
+            "/v1/chat/completions",
+            PathItem::new(HttpMethod::Post, op("Create a chat completion")),
+        )
+        .path(
+            "/v1/messages",
+            PathItem::new(HttpMethod::Post, op("Create a message (Anthropic format)")),
+        )
+        .path(
+            "/v1/embeddings",
+            PathItem::new(HttpMethod::Post, op("Create embeddings")),
+        )
+        .path(
+            "/v1/images/generations",
+            PathItem::new(HttpMethod::Post, op("Generate images")),
+        )
+        .path(
+            "/v1/audio/speech",
+            PathItem::new(HttpMethod::Post, op("Generate speech audio")),
+        )
+        .path(
+            "/v1/audio/transcriptions",
+            PathItem::new(HttpMethod::Post, op("Transcribe audio")),
+        )
+        .path(
+            "/v1/models",
+            PathItem::new(HttpMethod::Get, op("List available models")),
+        )
+        .path(
+            "/v1/usage",
+            PathItem::new(
+                HttpMethod::Get,
+                op("Get usage for the authenticated key").parameter(query("model")),
+            ),
+        )
+        // ── Admin — keys ──
+        .path(
+            "/v1/admin/keys",
+            multi(&[
+                (HttpMethod::Post, "Create a virtual API key"),
+                (HttpMethod::Get, "List all virtual keys"),
+            ]),
+        )
+        .path(
+            "/v1/admin/keys/{name}",
+            multi(&[
+                (HttpMethod::Get, "Get key details"),
+                (HttpMethod::Patch, "Update a key (models, rate_limit)"),
+                (HttpMethod::Delete, "Revoke a virtual key"),
+            ]),
+        )
+        // ── Admin — models ──
+        .path(
+            "/v1/admin/models",
+            PathItem::new(HttpMethod::Get, op("List model metadata")),
+        )
+        .path(
+            "/v1/admin/models/flush",
+            PathItem::new(HttpMethod::Post, op("Flush model overrides to config")),
+        )
+        .path(
+            "/v1/admin/models/{model}",
+            multi(&[
+                (HttpMethod::Get, "Get model metadata"),
+                (HttpMethod::Put, "Upsert model metadata"),
+                (HttpMethod::Delete, "Remove model override"),
+            ]),
+        )
+        // ── Admin — providers ──
+        .path(
+            "/v1/admin/providers/reload",
+            PathItem::new(HttpMethod::Post, op("Reload provider registry from config")),
+        )
+        // ── Admin — usage, logs, budget, cache ──
+        .path(
+            "/v1/admin/usage",
+            PathItem::new(
+                HttpMethod::Get,
+                op("Global usage view")
+                    .parameter(query("name"))
+                    .parameter(query("model")),
+            ),
+        )
+        .path(
+            "/v1/admin/logs",
+            PathItem::new(
+                HttpMethod::Get,
+                op("Query audit logs")
+                    .parameter(query("key"))
+                    .parameter(query("model"))
+                    .parameter(query("since"))
+                    .parameter(query("until"))
+                    .parameter(query("limit")),
+            ),
+        )
+        .path(
+            "/v1/budget",
+            PathItem::new(HttpMethod::Get, op("Get budget status per key")),
+        )
+        .path(
+            "/v1/cache",
+            PathItem::new(HttpMethod::Delete, op("Clear response cache")),
+        )
+        // ── Infrastructure ──
+        .path(
+            "/health",
+            PathItem::new(HttpMethod::Get, op("Health check")),
+        )
+        .path(
+            "/metrics",
+            PathItem::new(HttpMethod::Get, op("Prometheus metrics")),
+        )
+        .build();
+
+    utoipa::openapi::OpenApiBuilder::new()
+        .info(
+            InfoBuilder::new()
+                .title("CrabLLM API")
+                .version(env!("CARGO_PKG_VERSION"))
+                .description(Some("High-performance LLM API gateway"))
+                .build(),
+        )
+        .paths(paths)
+        .security(Some(vec![SecurityRequirement::new(
+            "BearerAuth",
+            Vec::<String>::new(),
+        )]))
+        .components(Some(
+            ComponentsBuilder::new()
+                .security_scheme(
+                    "BearerAuth",
+                    SecurityScheme::Http(HttpBuilder::new().scheme(HttpAuthScheme::Bearer).build()),
+                )
+                .build(),
+        ))
+        .build()
+}


### PR DESCRIPTION
Closes #66

## Summary

- Deduplicate three identical admin auth middleware implementations into shared `check_admin_token()` and `err_response()` helpers
- Centralize scattered storage prefix constants (`*b"keys"`, `*b"modl"`, etc.) into `proxy/lib.rs`
- Add `KeyRateLimit` struct and optional `rate_limit` field to `KeyConfig` for per-key RPM/TPM overrides
- Add `PATCH /v1/admin/keys/{name}` with JSON Merge Patch semantics — supports updating `models` and `rate_limit`, rejects immutable `name`/`key` fields, 403 for TOML-managed keys
- Rate limit extension reads per-key config from storage per-request, falls back to global defaults
- TOML key configs persisted to storage at startup so extensions can look them up uniformly
- `GET /v1/usage` now sits behind auth and auto-scopes to the caller's key — users only see their own usage
- `GET /v1/admin/usage?name=&model=` provides the admin global view with filtering
- Add OpenAPI documentation behind `--features openapi` + `openapi = true` in config TOML — serves Scalar UI at `/docs` and spec at `/openapi.json`
- `utoipa` is an optional dependency in core (feature-gated `cfg_attr` derives), manual `ToSchema` impls consolidated in `core/src/openapi.rs`

## Test plan

- [ ] `cargo build` / `cargo clippy` clean (with and without `--features openapi`)
- [ ] Create a dynamic key with `rate_limit` via `POST /v1/admin/keys`, verify enforcement
- [ ] `PATCH /v1/admin/keys/{name}` updates models and rate_limit correctly
- [ ] `PATCH` with `name` or `key` in body returns 400, TOML keys return 403
- [ ] `GET /v1/usage` returns only the caller's own usage
- [ ] `GET /v1/admin/usage?name=alice&model=gpt-4o` filters correctly
- [ ] With `openapi = true` + feature enabled: `GET /docs` renders Scalar UI, `GET /openapi.json` returns valid spec
- [ ] Without feature or config: `/docs` and `/openapi.json` return 404