### PR TITLE
chore: mlx, proxy, and provider batch updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "crabctl"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "clap",
  "dirs",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "arc-swap",
  "axum",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-bench"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "axum",
  "clap",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-core"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bytes",
  "futures-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-llamacpp"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "axum",
  "clap",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-mlx"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "base64",
  "clap",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-provider"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bytes",
  "crabllm-core",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "crabllm-proxy"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "network-programming"]
 
 [workspace.dependencies]
 crabllm-core = { version = "0.0.16", path = "crates/core" }
-crabllm-provider = { version = "0.0.16", path = "crates/provider" }
+crabllm-provider = { version = "0.0.16", path = "crates/provider", default-features = false }
 crabllm-proxy = { version = "0.0.16", path = "crates/proxy" }
 crabllm-bench = { version = "0.0.16", path = "crates/bench" }
 crabllm = { version = "0.0.16", path = "crates/crabllm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "High-performance LLM API gateway"
@@ -12,14 +12,14 @@ keywords = ["llm", "gateway", "proxy", "openai", "anthropic"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [workspace.dependencies]
-crabllm-core = { version = "0.0.16", path = "crates/core" }
-crabllm-provider = { version = "0.0.16", path = "crates/provider", default-features = false }
-crabllm-proxy = { version = "0.0.16", path = "crates/proxy" }
-crabllm-bench = { version = "0.0.16", path = "crates/bench" }
-crabllm = { version = "0.0.16", path = "crates/crabllm" }
-crabllm-llamacpp = { version = "0.0.16", path = "crates/llamacpp" }
-crabllm-mlx = { version = "0.0.16", path = "crates/mlx" }
-crabctl = { version = "0.0.16", path = "crates/crabctl" }
+crabllm-core = { version = "0.0.17", path = "crates/core" }
+crabllm-provider = { version = "0.0.17", path = "crates/provider", default-features = false }
+crabllm-proxy = { version = "0.0.17", path = "crates/proxy" }
+crabllm-bench = { version = "0.0.17", path = "crates/bench" }
+crabllm = { version = "0.0.17", path = "crates/crabllm" }
+crabllm-llamacpp = { version = "0.0.17", path = "crates/llamacpp" }
+crabllm-mlx = { version = "0.0.17", path = "crates/mlx" }
+crabctl = { version = "0.0.17", path = "crates/crabctl" }
 
 # crates-io
 axum = { version = "0.8", features = ["multipart"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ hyper = { version = "1", features = ["client", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["ring", "http1", "http2", "tls12", "native-tokio", "logging"] }
 hyper-tls = "0.6"
-native-tls-crate = { package = "native-tls", version = "0.2", features = ["alpn"] }
+native-tls = { version = "0.2", features = ["alpn"] }
 http-body-util = "0.1"
 http = "1"
 tokio = { version = "1", features = ["full"] }
@@ -74,3 +74,5 @@ debug = false
 debug-assertions = false
 overflow-checks = false
 strip = true
+
+[workspace.metadata.conta]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -313,7 +313,6 @@ impl GatewayConfig {
         }
         Ok(())
     }
-
 }
 
 /// Expand `${VAR}` patterns in a string using environment variables.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -40,10 +40,6 @@ pub struct GatewayConfig {
     /// Entries are merged into `models` at startup (config entries win).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cloud_models: Option<String>,
-    /// Path to local model registry TOML file (alias → HF repo ID).
-    /// Extends the build-time MLX model registry.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub local_models: Option<String>,
     /// Admin API bearer token. If set, enables /v1/admin/* endpoints.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub admin_token: Option<String>,
@@ -278,29 +274,6 @@ impl StorageConfig {
     }
 }
 
-/// A single local model entry: HF repo ID and optional disk size.
-#[derive(Debug, Clone, Deserialize)]
-pub struct LocalModelEntry {
-    pub repo_id: String,
-    /// Approximate disk size in megabytes.
-    #[serde(default)]
-    pub size_mb: Option<u64>,
-    /// Whether the model accepts image/video input (VLM).
-    #[serde(default)]
-    pub vision: Option<bool>,
-    /// Architecture / model_type from HuggingFace config (e.g. `"qwen2"`, `"llama"`).
-    #[serde(default)]
-    pub arch: Option<String>,
-}
-
-/// Wrapper for local model TOML: `[models.family.size.quant]` nested tables.
-#[cfg(feature = "gateway")]
-#[derive(Deserialize)]
-struct LocalModelsFile {
-    #[serde(default)]
-    models: HashMap<String, HashMap<String, HashMap<String, LocalModelEntry>>>,
-}
-
 impl GatewayConfig {
     /// Load config from a TOML file, expanding `${VAR}` patterns in
     /// string values. If `cloud_models` is set, loads the referenced
@@ -341,35 +314,6 @@ impl GatewayConfig {
         Ok(())
     }
 
-    /// Load local model entries from the configured TOML file.
-    ///
-    /// The TOML uses nested tables `[models.family.size.quant]`. This
-    /// flattens them to `"family.size.quant" → entry` for consumers.
-    #[cfg(feature = "gateway")]
-    pub fn load_local_models(
-        &self,
-        config_dir: &std::path::Path,
-    ) -> Result<HashMap<String, LocalModelEntry>, Box<dyn std::error::Error>> {
-        let Some(ref path) = self.local_models else {
-            return Ok(HashMap::new());
-        };
-        let full = config_dir.join(path);
-        let raw = std::fs::read_to_string(&full)
-            .map_err(|e| format!("local_models '{}': {e}", full.display()))?;
-        let file: LocalModelsFile =
-            toml::from_str(&raw).map_err(|e| format!("local_models '{}': {e}", full.display()))?;
-
-        let mut result = HashMap::new();
-        for (family, sizes) in file.models {
-            for (size, quants) in sizes {
-                for (quant, entry) in quants {
-                    let alias = format!("{family}.{size}.{quant}");
-                    result.insert(alias, entry);
-                }
-            }
-        }
-        Ok(result)
-    }
 }
 
 /// Expand `${VAR}` patterns in a string using environment variables.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,6 @@
 pub use config::{
-    GatewayConfig, KeyConfig, KeyRateLimit, LocalModelEntry, PricingConfig, ProviderConfig,
-    ProviderKind, StorageConfig,
+    GatewayConfig, KeyConfig, KeyRateLimit, PricingConfig, ProviderConfig, ProviderKind,
+    StorageConfig,
 };
 pub use error::{ApiError, ApiErrorBody, Error};
 pub use extension::{Extension, ExtensionError, RequestContext};

--- a/crates/core/src/types/anthropic.rs
+++ b/crates/core/src/types/anthropic.rs
@@ -13,7 +13,8 @@ pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 pub struct ThinkingConfig {
     #[serde(rename = "type")]
     pub kind: String,
-    pub budget_tokens: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -190,6 +190,8 @@ pub struct ChatCompletionRequest {
     pub reasoning_effort: Option<String>,
     #[serde(skip)]
     pub thinking: Option<crate::types::anthropic::ThinkingConfig>,
+    #[serde(skip)]
+    pub anthropic_max_tokens: Option<u32>,
     #[serde(flatten, default)]
     #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -188,6 +188,8 @@ pub struct ChatCompletionRequest {
     pub user: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
+    #[serde(skip)]
+    pub thinking: Option<crate::types::anthropic::ThinkingConfig>,
     #[serde(flatten, default)]
     #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
     pub extra: serde_json::Map<String, serde_json::Value>,

--- a/crates/llamacpp/Cargo.toml
+++ b/crates/llamacpp/Cargo.toml
@@ -33,3 +33,7 @@ flate2 = { workspace = true }
 tar = { workspace = true }
 zip = { workspace = true }
 dirs = { workspace = true }
+
+[features]
+default = ["native-tls"]
+native-tls = ["crabllm-provider/native-tls"]

--- a/crates/llamacpp/Cargo.toml
+++ b/crates/llamacpp/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Managed llama.cpp server with Ollama registry support"
-keywords = ["llm", "llamacpp", "gguf", "local", "inference", "ollama"]
+keywords = ["llm", "llamacpp", "gguf", "local", "inference"]
 categories = ["command-line-utilities"]
 
 [[bin]]

--- a/crates/mlx/build.rs
+++ b/crates/mlx/build.rs
@@ -365,7 +365,7 @@ fn generate_model_registry(mlx_dir: &Path) {
                 check_str(repo_id, "repo_id");
                 check_str(arch, "arch");
 
-                let alias = format!("{family}.{param_size}.{quant}");
+                let alias = format!("{family}-{param_size}-{quant}");
                 code.push_str(&format!(
                     "    ModelEntry {{ alias: \"{alias}\", repo_id: \"{repo_id}\", \
                      kind: {kind}, size_mb: {size_mb}, \

--- a/crates/mlx/src/registry.rs
+++ b/crates/mlx/src/registry.rs
@@ -22,7 +22,7 @@ pub enum ModelKind {
 /// A model entry from the registry.
 #[derive(Debug, Clone, Copy)]
 pub struct ModelEntry {
-    /// Lowercase alias: `"family.param_size.quant"` (e.g. `"qwen3.5.2b.4bit"`).
+    /// Lowercase alias: `"family-param_size-quant"` (e.g. `"qwen3.5-2b-4bit"`).
     pub alias: &'static str,
     /// Full HuggingFace repo id (e.g. `"mlx-community/Qwen3.5-2B-MLX-4bit"`).
     pub repo_id: &'static str,
@@ -52,7 +52,7 @@ pub fn list() -> &'static [ModelEntry] {
 ///
 /// Accepts:
 ///   * A full repo id (`"mlx-community/Qwen3.5-2B-MLX-4bit"`) — returned as-is.
-///   * A lowercase alias (`"qwen3.5.2b.4bit"`) — looked up in the registry.
+///   * A lowercase alias (`"qwen3.5-2b-4bit"`) — looked up in the registry.
 ///
 /// Returns `None` if the input is not a full repo id (no `/`) and
 /// not a known alias.

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["llm", "openai", "anthropic", "gemini", "bedrock"]
 categories = ["web-programming::http-client", "network-programming"]
 
 [features]
-native-tls = ["dep:hyper-tls", "dep:native-tls-crate"]
+default = ["native-tls"]
+native-tls = ["dep:hyper-tls", "dep:native-tls"]
 rustls = ["dep:hyper-rustls"]
 provider-bedrock = ["hmac", "sha2"]
 
@@ -26,7 +27,7 @@ hyper.workspace = true
 hyper-util.workspace = true
 hyper-rustls = { workspace = true, optional = true }
 hyper-tls = { workspace = true, optional = true }
-native-tls-crate = { workspace = true, optional = true }
+native-tls = { workspace = true, optional = true }
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/provider/src/client.rs
+++ b/crates/provider/src/client.rs
@@ -62,7 +62,7 @@ impl HttpClient {
     fn connector() -> Connector {
         let mut http = hyper_util::client::legacy::connect::HttpConnector::new();
         http.enforce_http(false);
-        let tls = native_tls_crate::TlsConnector::builder()
+        let tls = native_tls::TlsConnector::builder()
             .request_alpns(&["h2", "http/1.1"])
             .build()
             .expect("crabllm: failed to build native TLS connector");

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -18,6 +18,7 @@ mod provider;
 mod registry;
 
 pub use client::{ByteStream, HttpClient};
+pub use provider::schema;
 
 /// Exposed so `crabllm-llamacpp` can reuse the OpenAI-compatible HTTP
 /// helpers against the child llama-server process. Append-only surface —

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -249,25 +249,26 @@ fn translate_request(request: &ChatCompletionRequest) -> AnthropicRequest {
 
     let max_tokens = request.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
 
-    // Derive thinking config from request.extra["thinking"].
-    let thinking = request.extra.get("thinking").and_then(|v| {
-        if v.as_bool() == Some(true) {
-            Some(ThinkingConfig {
-                kind: "enabled".to_string(),
-                budget_tokens: max_tokens.saturating_sub(1),
-            })
-        } else if let Some(obj) = v.as_object() {
-            let budget = obj
-                .get("budget_tokens")
-                .and_then(|b| b.as_u64())
-                .unwrap_or(max_tokens.saturating_sub(1) as u64) as u32;
-            Some(ThinkingConfig {
-                kind: "enabled".to_string(),
-                budget_tokens: budget,
-            })
-        } else {
-            None
-        }
+    let thinking = request.thinking.clone().or_else(|| {
+        request.extra.get("thinking").and_then(|v| {
+            if v.as_bool() == Some(true) {
+                Some(ThinkingConfig {
+                    kind: "enabled".to_string(),
+                    budget_tokens: Some(max_tokens.saturating_sub(1)),
+                })
+            } else if let Some(obj) = v.as_object() {
+                let budget = obj
+                    .get("budget_tokens")
+                    .and_then(|b| b.as_u64())
+                    .map(|b| b as u32);
+                Some(ThinkingConfig {
+                    kind: "enabled".to_string(),
+                    budget_tokens: budget,
+                })
+            } else {
+                None
+            }
+        })
     });
 
     AnthropicRequest {

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -247,7 +247,10 @@ fn translate_request(request: &ChatCompletionRequest) -> AnthropicRequest {
         Stop::Multiple(v) => v.clone(),
     });
 
-    let max_tokens = request.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+    let max_tokens = request
+        .anthropic_max_tokens
+        .or(request.max_tokens)
+        .unwrap_or(DEFAULT_MAX_TOKENS);
 
     let thinking = request.thinking.clone().or_else(|| {
         request.extra.get("thinking").and_then(|v| {

--- a/crates/provider/src/provider/google.rs
+++ b/crates/provider/src/provider/google.rs
@@ -10,7 +10,6 @@ use futures::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
 
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
-const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 // ── Gemini-native request types ──
 
@@ -270,7 +269,7 @@ fn translate_request(request: &ChatCompletionRequest) -> GeminiRequest {
     });
 
     let generation_config = Some(GenerationConfig {
-        max_output_tokens: Some(request.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS)),
+        max_output_tokens: request.anthropic_max_tokens.or(request.max_tokens),
         temperature: request.temperature,
         top_p: request.top_p,
         stop_sequences,

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -3,4 +3,4 @@ pub mod azure;
 pub mod bedrock;
 pub mod google;
 pub mod openai;
-pub(crate) mod schema;
+pub mod schema;

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -166,7 +166,7 @@ impl<P> ProviderRegistry<P> {
             .enumerate()
             .filter(|(i, _)| *i != selected_idx)
             .collect();
-        remaining.sort_by(|a, b| b.1.weight.cmp(&a.1.weight));
+        remaining.sort_by_key(|b| std::cmp::Reverse(b.1.weight));
         result.extend(remaining.into_iter().map(|(_, d)| d.as_ref()));
 
         Some(result)

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["llm", "proxy", "openai", "streaming", "gateway"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [features]
+default = ["native-tls"]
 native-tls = ["crabllm-provider/native-tls"]
 rustls = ["crabllm-provider/rustls"]
 storage-redis = ["redis"]

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -55,7 +55,7 @@ pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
         messages,
         temperature: req.temperature,
         top_p: req.top_p,
-        max_tokens: Some(req.max_tokens),
+        max_tokens: None,
         stream: req.stream,
         stop,
         tools,
@@ -66,6 +66,7 @@ pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
         user: None,
         reasoning_effort: None,
         thinking: req.thinking,
+        anthropic_max_tokens: Some(req.max_tokens),
         extra: serde_json::Map::new(),
     }
 }
@@ -255,12 +256,18 @@ fn image_source_to_url(source: &serde_json::Value) -> Option<String> {
 }
 
 fn convert_tool(t: AnthropicTool) -> Tool {
+    let mut schema = t.input_schema;
+    crabllm_provider::schema::inline_refs(&mut schema);
+    crabllm_provider::schema::strip_fields(
+        &mut schema,
+        &["propertyNames", "exclusiveMinimum", "exclusiveMaximum", "const"],
+    );
     Tool {
         kind: ToolType::Function,
         function: FunctionDef {
             name: t.name,
             description: t.description,
-            parameters: Some(t.input_schema),
+            parameters: Some(schema),
         },
         strict: None,
     }

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -50,17 +50,6 @@ pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
         .map(|tools| tools.into_iter().map(convert_tool).collect());
     let tool_choice = req.tool_choice.as_ref().and_then(translate_tool_choice);
 
-    let mut extra = serde_json::Map::new();
-    if let Some(thinking) = req.thinking {
-        extra.insert(
-            "thinking".to_string(),
-            serde_json::json!({
-                "type": thinking.kind,
-                "budget_tokens": thinking.budget_tokens,
-            }),
-        );
-    }
-
     ChatCompletionRequest {
         model: req.model,
         messages,
@@ -76,7 +65,8 @@ pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
         seed: None,
         user: None,
         reasoning_effort: None,
-        extra,
+        thinking: req.thinking,
+        extra: serde_json::Map::new(),
     }
 }
 

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -260,7 +260,12 @@ fn convert_tool(t: AnthropicTool) -> Tool {
     crabllm_provider::schema::inline_refs(&mut schema);
     crabllm_provider::schema::strip_fields(
         &mut schema,
-        &["propertyNames", "exclusiveMinimum", "exclusiveMaximum", "const"],
+        &[
+            "propertyNames",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "const",
+        ],
     );
     Tool {
         kind: ToolType::Function,

--- a/crates/proxy/src/ext/audit.rs
+++ b/crates/proxy/src/ext/audit.rs
@@ -116,6 +116,7 @@ impl crabllm_core::Extension for AuditLogger {
             cost_micros,
             latency_ms: ctx.started_at.elapsed().as_millis() as u64,
             status: 200,
+            error: None,
         });
 
         Box::pin(async {})
@@ -145,6 +146,7 @@ impl crabllm_core::Extension for AuditLogger {
                 cost_micros,
                 latency_ms: ctx.started_at.elapsed().as_millis() as u64,
                 status: 200,
+                error: None,
             });
         }
 
@@ -163,6 +165,7 @@ impl crabllm_core::Extension for AuditLogger {
             cost_micros: 0,
             latency_ms: ctx.started_at.elapsed().as_millis() as u64,
             status: error_status(error),
+            error: Some(error.to_string()),
         });
 
         Box::pin(async {})
@@ -183,6 +186,8 @@ pub struct AuditRecord {
     pub cost_micros: i64,
     pub latency_ms: u64,
     pub status: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/crates/proxy/src/ext/audit.rs
+++ b/crates/proxy/src/ext/audit.rs
@@ -170,19 +170,19 @@ impl crabllm_core::Extension for AuditLogger {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct AuditRecord {
-    request_id: String,
-    timestamp: i64,
-    key_name: String,
-    model: String,
-    provider: String,
+pub struct AuditRecord {
+    pub request_id: String,
+    pub timestamp: i64,
+    pub key_name: String,
+    pub model: String,
+    pub provider: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    prompt_tokens: Option<u32>,
+    pub prompt_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    completion_tokens: Option<u32>,
-    cost_micros: i64,
-    latency_ms: u64,
-    status: u16,
+    pub completion_tokens: Option<u32>,
+    pub cost_micros: i64,
+    pub latency_ms: u64,
+    pub status: u16,
 }
 
 #[derive(Deserialize)]

--- a/crates/proxy/src/ext/audit.rs
+++ b/crates/proxy/src/ext/audit.rs
@@ -257,7 +257,7 @@ async fn logs_handler(
         .collect();
 
     // Newest first.
-    records.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    records.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     records.truncate(query.limit);
 
     Json(records).into_response()

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -99,7 +99,6 @@ fn empty_config() -> GatewayConfig {
         aliases: HashMap::new(),
         models: HashMap::new(),
         cloud_models: None,
-        local_models: None,
         admin_token: None,
         shutdown_timeout: 30,
         openapi: true,

--- a/mlx/Package.swift
+++ b/mlx/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 // CrabllmMlx — Swift static library that sits behind the crabllm_mlx.h
-// C ABI. Tracks mlx-swift-lm main (post-2.31.3, breaking 3.x series).
+// C ABI. Tracks mlx-swift-lm 3.x (Gemma 4 support).
 let package = Package(
     name: "CrabllmMlx",
     platforms: [
@@ -17,12 +17,9 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // Pin to 780048f — the latest commit before ec9619b which
-        // introduced a Swift 6 Sendable violation in
-        // Llama3ToolCallParser.swift. Track main once that's fixed.
         .package(
             url: "https://github.com/ml-explore/mlx-swift-lm.git",
-            revision: "780048f"
+            from: "3.31.3"
         ),
         // swift-transformers provides AutoTokenizer, needed by the
         // #huggingFaceTokenizerLoader() macro. mlx-swift-lm 3.x

--- a/mlx/Sources/CrabllmMlx/MessageParsing.swift
+++ b/mlx/Sources/CrabllmMlx/MessageParsing.swift
@@ -284,8 +284,22 @@ func transcribeAudio(data b64: String, format: String) throws -> String {
     try audioData.write(to: tempFile)
     defer { try? FileManager.default.removeItem(at: tempFile) }
 
+    let onDevice = recognizer.supportsOnDeviceRecognition
+
+    // SFSpeechRecognizer delivers callbacks through `recognizer.queue`,
+    // which defaults to `OperationQueue.main`. In a Rust subprocess the
+    // main thread runs tokio — it never services the main operation
+    // queue — so the default wiring hangs forever. Give the recognizer
+    // its own queue so callbacks land on a GCD worker we actually run.
+    let deliveryQueue = OperationQueue()
+    deliveryQueue.maxConcurrentOperationCount = 1
+    recognizer.queue = deliveryQueue
+
     let request = SFSpeechURLRecognitionRequest(url: tempFile)
     request.shouldReportPartialResults = false
+    if onDevice {
+        request.requiresOnDeviceRecognition = true
+    }
 
     let semaphore = DispatchSemaphore(value: 0)
     nonisolated(unsafe) var transcript: String?
@@ -308,10 +322,19 @@ func transcribeAudio(data b64: String, format: String) throws -> String {
         task.cancel()
         throw FFIError.invalidArg("input_audio: transcription exceeded \(Int(audioTranscriptionTimeout))s timeout")
     }
+
     if let error = recognitionError {
         throw FFIError.invalidArg("input_audio: transcription failed: \(error)")
     }
-    return transcript ?? ""
+    let text = transcript ?? ""
+    if text.isEmpty {
+        throw FFIError.invalidArg(
+            "input_audio: no speech detected in the clip. Check mic input "
+            + "and that System Settings → Privacy & Security → Speech "
+            + "Recognition is enabled for CrabDash."
+        )
+    }
+    return text
 }
 
 /// Decode a `data:[<mediatype>];base64,<payload>` URL. Anchors on the

--- a/models/local.toml
+++ b/models/local.toml
@@ -1020,6 +1020,177 @@ size_mb = 6312
 vision = true
 arch = "gemma3"
 
+[models.gemma-3n.e2b.4bit]
+repo_id = "mlx-community/gemma-3n-E2B-4bit"
+size_mb = 3191
+arch = "gemma3n"
+
+[models.gemma-4.31b.4bit]
+repo_id = "mlx-community/gemma-4-31b-4bit"
+size_mb = 10238
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.31b.6bit]
+repo_id = "mlx-community/gemma-4-31b-6bit"
+size_mb = 13898
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.31b.8bit]
+repo_id = "mlx-community/gemma-4-31b-8bit"
+size_mb = 17558
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e2b.4bit]
+repo_id = "mlx-community/gemma-4-e2b-4bit"
+size_mb = 2309
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e2b.6bit]
+repo_id = "mlx-community/gemma-4-e2b-6bit"
+size_mb = 2862
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e2b.8bit]
+repo_id = "mlx-community/gemma-4-e2b-8bit"
+size_mb = 3414
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e4b.4bit]
+repo_id = "mlx-community/gemma-4-e4b-4bit"
+size_mb = 3188
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e4b.6bit]
+repo_id = "mlx-community/gemma-4-e4b-6bit"
+size_mb = 4081
+vision = true
+arch = "gemma4"
+
+[models.gemma-4.e4b.8bit]
+repo_id = "mlx-community/gemma-4-e4b-8bit"
+size_mb = 4975
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b.26b.4bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-4bit"
+size_mb = 8738
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b.26b.6bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-6bit"
+size_mb = 11681
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b.26b.8bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-8bit"
+size_mb = 14625
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b-it.26b.4bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-it-4bit"
+size_mb = 8738
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b-it.26b.6bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-it-6bit"
+size_mb = 11681
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b-it.26b.8bit]
+repo_id = "mlx-community/gemma-4-26b-a4b-it-8bit"
+size_mb = 14625
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-a4b-it-heretic.26b.4bit]
+repo_id = "mlx-community/gemma-4-26B-A4B-it-heretic-4bit"
+size_mb = 8738
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.31b.4bit]
+repo_id = "mlx-community/gemma-4-31b-it-4bit"
+size_mb = 10238
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.31b.6bit]
+repo_id = "mlx-community/gemma-4-31b-it-6bit"
+size_mb = 13898
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.31b.8bit]
+repo_id = "mlx-community/gemma-4-31b-it-8bit"
+size_mb = 17558
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e2b.4bit]
+repo_id = "mlx-community/gemma-4-e2b-it-4bit"
+size_mb = 2309
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e2b.6bit]
+repo_id = "mlx-community/gemma-4-e2b-it-6bit"
+size_mb = 2862
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e2b.8bit]
+repo_id = "mlx-community/gemma-4-e2b-it-8bit"
+size_mb = 3414
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e4b.4bit]
+repo_id = "mlx-community/gemma-4-e4b-it-4bit"
+size_mb = 3188
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e4b.6bit]
+repo_id = "mlx-community/gemma-4-e4b-it-6bit"
+size_mb = 4081
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it.e4b.8bit]
+repo_id = "mlx-community/gemma-4-e4b-it-8bit"
+size_mb = 4975
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it-obliterated.e4b.8bit]
+repo_id = "mlx-community/gemma-4-E4B-it-OBLITERATED-mlx-8Bit"
+size_mb = 4033
+vision = true
+arch = "gemma4"
+
+[models.gemma-4-it-optiq.e2b.4bit]
+repo_id = "mlx-community/gemma-4-e2b-it-OptiQ-4bit"
+size_mb = 2127
+arch = "gemma4_text"
+
+[models.gemma-4-it-optiq.e4b.4bit]
+repo_id = "mlx-community/gemma-4-e4b-it-OptiQ-4bit"
+size_mb = 3238
+arch = "gemma4_text"
+
 [models.gemma-sea-lion-v3-it.9b.4bit]
 repo_id = "mlx-community/Gemma-SEA-LION-v3-9B-IT-mlx-4bit"
 size_mb = 3306
@@ -1323,6 +1494,21 @@ arch = "gemma3_text"
 repo_id = "mlx-community/Huihui-gemma-3-270m-it-abliterated-8bit"
 size_mb = 143
 arch = "gemma3_text"
+
+[models.huihui-gemma-3n-it-abliterated-lm.e4b.4bit]
+repo_id = "mlx-community/Huihui-gemma-3n-E4B-it-abliterated-lm-4bit"
+size_mb = 2047
+arch = "gemma3n"
+
+[models.huihui-gemma-3n-it-abliterated-lm.e4b.6bit]
+repo_id = "mlx-community/Huihui-gemma-3n-E4B-it-abliterated-lm-6bit"
+size_mb = 2865
+arch = "gemma3n"
+
+[models.huihui-gemma-3n-it-abliterated-lm.e4b.8bit]
+repo_id = "mlx-community/Huihui-gemma-3n-E4B-it-abliterated-lm-8bit"
+size_mb = 3684
+arch = "gemma3n"
 
 [models."huihui-lfm2.5-instruct-abliterated"."1.2b".4bit]
 repo_id = "mlx-community/Huihui-LFM2.5-1.2B-Instruct-abliterated-4bit"
@@ -3391,6 +3577,24 @@ arch = "qwen3_5"
 [models."qwen3.5-reap-a10b".97b.4bit]
 repo_id = "mlx-community/Qwen3.5-REAP-97B-A10B-4bit"
 size_mb = 28840
+vision = true
+arch = "qwen3_5_moe"
+
+[models."qwen3.6-a3b".35b.4bit]
+repo_id = "mlx-community/Qwen3.6-35B-A3B-4bit"
+size_mb = 11188
+vision = true
+arch = "qwen3_5_moe"
+
+[models."qwen3.6-a3b".35b.6bit]
+repo_id = "mlx-community/Qwen3.6-35B-A3B-6bit"
+size_mb = 15317
+vision = true
+arch = "qwen3_5_moe"
+
+[models."qwen3.6-a3b".35b.8bit]
+repo_id = "mlx-community/Qwen3.6-35B-A3B-8bit"
+size_mb = 19446
 vision = true
 arch = "qwen3_5_moe"
 

--- a/scripts/update_local_models.py
+++ b/scripts/update_local_models.py
@@ -67,8 +67,9 @@ def parse_model(repo_id: str) -> tuple[str, str, str] | None:
 
     # Extract quant suffix (e.g., "4bit", "8bit").
     quant_match = re.search(r"-(\d+bit)$", name)
-    # Extract param size (e.g., "2b", "70b", "0.5b", "135m").
-    size_match = re.search(r"-(\d+(?:\.\d+)?[bm])(?=-|$)", name)
+    # Extract param size (e.g., "2b", "70b", "0.5b", "135m", "e2b", "e4b").
+    # The `e` prefix denotes Gemma 3n / Gemma 4 effective-param variants.
+    size_match = re.search(r"-(e?\d+(?:\.\d+)?[bm])(?=-|$)", name)
 
     if not (size_match and quant_match):
         return None


### PR DESCRIPTION
## Summary
- **mlx**: bump `mlx-swift-lm` to 3.31.3 (unblocks Gemma 4), dispatch speech callbacks off the main queue to fix hangs under tokio, switch alias separator from `.` to `-`
- **proxy**: fix `max_tokens` overflow against non-Anthropic upstreams (DeepSeek, etc.) by separating wire `max_tokens` from Anthropic's required value; strip unsupported JSON Schema keywords (`propertyNames`, `exclusiveMinimum/Maximum`, `const`) from tool schemas; persist error messages through audit + usage stream
- **core**: promote `thinking` to a typed field on `ChatCompletionRequest`; drop unused `LocalModelEntry` / `local_models` config
- **provider**: default to `native-tls`; make `AuditRecord` public
- **llamacpp**: add manifest

## Test plan
- [ ] `cargo check --workspace`
- [ ] Anthropic-translated request against DeepSeek does not 400 on `max_tokens`
- [ ] Gemini tool-call request succeeds with schemas containing previously-rejected keywords
- [ ] MLX speech recognition returns transcript under tokio runtime (no hang)
- [ ] Gemma 4 model loads via mlx registry