### PR TITLE
refactor(core): ContentBlock migration, DeepSeek provider, and provider fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Install Toolchain
         run: rustup update stable && rustup default stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
+      # - name: Install protoc
+      #   uses: arduino/setup-protoc@v3
       - uses: taiki-e/install-action@sccache
       - uses: taiki-e/install-action@nextest
       - name: Build
@@ -38,8 +38,8 @@ jobs:
           rustup update stable && rustup default stable
           rustup component add clippy rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
+      # - name: Install protoc
+      #   uses: arduino/setup-protoc@v3
       - uses: taiki-e/install-action@sccache
       - name: Format
         run: cargo fmt --check

--- a/crates/bench/src/bin/main.rs
+++ b/crates/bench/src/bin/main.rs
@@ -182,17 +182,7 @@ fn canned_chat_response() -> ChatCompletionResponse {
         model: "bench-chat".into(),
         choices: vec![Choice {
             index: 0,
-            message: Message {
-                role: Role::Assistant,
-                content: Some(serde_json::Value::String(
-                    "This is a benchmark response.".into(),
-                )),
-                tool_calls: None,
-                tool_call_id: None,
-                name: None,
-                reasoning_content: None,
-                extra: Default::default(),
-            },
+            message: Message::assistant("This is a benchmark response."),
             finish_reason: Some(FinishReason::Stop),
             logprobs: None,
         }],

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -113,6 +113,7 @@ pub enum ProviderKind {
     #[default]
     Openai,
     Anthropic,
+    Deepseek,
     Google,
     Bedrock,
     Ollama,
@@ -127,6 +128,7 @@ impl ProviderKind {
         match self {
             Self::Openai => "openai",
             Self::Anthropic => "anthropic",
+            Self::Deepseek => "deepseek",
             Self::Google => "google",
             Self::Bedrock => "bedrock",
             Self::Ollama => "ollama",
@@ -159,6 +161,7 @@ impl<'de> serde::Deserialize<'de> for ProviderKind {
         Ok(match s.as_str() {
             "openai" => Self::Openai,
             "anthropic" => Self::Anthropic,
+            "deepseek" => Self::Deepseek,
             "google" => Self::Google,
             "bedrock" => Self::Bedrock,
             "ollama" => Self::Ollama,
@@ -175,8 +178,8 @@ impl ProviderConfig {
     /// or if `base_url` contains "anthropic". Otherwise returns the
     /// configured kind.
     pub fn effective_kind(&self) -> ProviderKind {
-        if self.kind == ProviderKind::Anthropic {
-            return ProviderKind::Anthropic;
+        if self.kind != ProviderKind::Openai {
+            return self.kind.clone();
         }
         if let Some(url) = &self.base_url
             && url.contains("anthropic")

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,10 +11,10 @@ pub use types::{
     AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
     AnthropicSystem, AnthropicTool, AnthropicUsage, AudioSpeechRequest, ChatCompletionChunk,
     ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, CompletionTokensDetails,
-    DEFAULT_MAX_TOKENS, Delta, Embedding, EmbeddingInput, EmbeddingRequest, EmbeddingResponse,
-    EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef, ImageRequest,
-    Message, Model, ModelList, MultipartField, Role, Stop, ThinkingConfig, Tool, ToolCall,
-    ToolCallDelta, ToolChoice, ToolResultContent, ToolType, Usage,
+    ContentBlock, DEFAULT_MAX_TOKENS, Delta, Embedding, EmbeddingInput, EmbeddingRequest,
+    EmbeddingResponse, EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef,
+    ImageRequest, Message, Model, ModelList, MultipartField, Role, Stop, ThinkingConfig, Tool,
+    ToolCall, ToolCallDelta, ToolChoice, ToolResultContent, ToolType, Usage,
 };
 
 mod config;

--- a/crates/core/src/types/anthropic.rs
+++ b/crates/core/src/types/anthropic.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 pub type AnthropicContentBlock = ContentBlock;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThinkingConfig {
     #[serde(rename = "type")]
     pub kind: String,
@@ -21,6 +22,7 @@ pub struct ThinkingConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AnthropicRequest {
     pub model: String,
     pub messages: Vec<AnthropicMessage>,
@@ -36,6 +38,7 @@ pub struct AnthropicRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<AnthropicTool>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub tool_choice: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop_sequences: Option<Vec<String>>,
@@ -45,6 +48,7 @@ pub struct AnthropicRequest {
 
 /// System prompt: either a plain string or an array of content blocks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum AnthropicSystem {
     Text(String),
@@ -52,6 +56,7 @@ pub enum AnthropicSystem {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AnthropicMessage {
     pub role: String,
     pub content: AnthropicContent,
@@ -59,6 +64,7 @@ pub struct AnthropicMessage {
 
 /// Message content: either a plain string or an array of content blocks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum AnthropicContent {
     Text(String),
@@ -66,14 +72,17 @@ pub enum AnthropicContent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AnthropicTool {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub input_schema: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AnthropicResponse {
     pub id: String,
     #[serde(default = "default_message_type")]
@@ -98,6 +107,7 @@ fn default_assistant_role() -> String {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AnthropicUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,

--- a/crates/core/src/types/anthropic.rs
+++ b/crates/core/src/types/anthropic.rs
@@ -1,13 +1,16 @@
 //! Anthropic Messages API wire types.
 //!
-//! These types are bidirectional — used both when crabllm acts as a client of
-//! the upstream Anthropic API (outbound, in the `provider` crate) and when
-//! crabllm exposes an Anthropic-compatible endpoint to its own clients
-//! (inbound, in the `proxy` crate).
+//! The canonical content-block types (`ContentBlock`, `ToolResultContent`) now
+//! live in `crate::types::chat`. This module re-exports them as
+//! `AnthropicContentBlock` for backward compatibility and defines the
+//! Anthropic-specific request/response envelope types.
 
+use crate::types::chat::ContentBlock;
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+pub type AnthropicContentBlock = ContentBlock;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThinkingConfig {
@@ -41,12 +44,11 @@ pub struct AnthropicRequest {
 }
 
 /// System prompt: either a plain string or an array of content blocks.
-/// Anthropic SDK clients send either form interchangeably.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AnthropicSystem {
     Text(String),
-    Blocks(Vec<AnthropicContentBlock>),
+    Blocks(Vec<ContentBlock>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,46 +62,7 @@ pub struct AnthropicMessage {
 #[serde(untagged)]
 pub enum AnthropicContent {
     Text(String),
-    Blocks(Vec<AnthropicContentBlock>),
-}
-
-/// A content block. Used in both requests and responses, so the variant set is
-/// the union of what either side can send; producers only emit valid variants
-/// for their direction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum AnthropicContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "image")]
-    Image { source: serde_json::Value },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: serde_json::Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: String,
-        content: ToolResultContent,
-    },
-    #[serde(rename = "thinking")]
-    Thinking {
-        #[serde(default, skip_serializing_if = "String::is_empty")]
-        thinking: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        signature: Option<String>,
-    },
-}
-
-/// Tool result content: Anthropic allows either a plain string or an array of
-/// text/image blocks nested inside the result.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ToolResultContent {
-    Text(String),
-    Blocks(Vec<AnthropicContentBlock>),
+    Blocks(Vec<ContentBlock>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -118,7 +81,7 @@ pub struct AnthropicResponse {
     #[serde(default = "default_assistant_role")]
     pub role: String,
     pub model: String,
-    pub content: Vec<AnthropicContentBlock>,
+    pub content: Vec<ContentBlock>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -254,21 +254,27 @@ impl Message {
     pub fn user(content: impl Into<String>) -> Self {
         Self {
             role: Role::User,
-            content: vec![ContentBlock::Text { text: content.into() }],
+            content: vec![ContentBlock::Text {
+                text: content.into(),
+            }],
         }
     }
 
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             role: Role::Assistant,
-            content: vec![ContentBlock::Text { text: content.into() }],
+            content: vec![ContentBlock::Text {
+                text: content.into(),
+            }],
         }
     }
 
     pub fn system(content: impl Into<String>) -> Self {
         Self {
             role: Role::System,
-            content: vec![ContentBlock::Text { text: content.into() }],
+            content: vec![ContentBlock::Text {
+                text: content.into(),
+            }],
         }
     }
 

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -296,10 +296,10 @@ impl Message {
     /// Concatenated text from all Text blocks, or `None` if empty.
     pub fn content_str(&self) -> Option<&str> {
         for block in &self.content {
-            if let ContentBlock::Text { text } = block {
-                if !text.is_empty() {
-                    return Some(text.as_str());
-                }
+            if let ContentBlock::Text { text } = block
+                && !text.is_empty()
+            {
+                return Some(text.as_str());
             }
         }
         None
@@ -316,10 +316,10 @@ impl Message {
     /// The thinking content, if any.
     pub fn thinking(&self) -> Option<&str> {
         for block in &self.content {
-            if let ContentBlock::Thinking { thinking, .. } = block {
-                if !thinking.is_empty() {
-                    return Some(thinking.as_str());
-                }
+            if let ContentBlock::Thinking { thinking, .. } = block
+                && !thinking.is_empty()
+            {
+                return Some(thinking.as_str());
             }
         }
         None

--- a/crates/core/src/types/chat.rs
+++ b/crates/core/src/types/chat.rs
@@ -204,74 +204,119 @@ pub enum Stop {
     Multiple(Vec<String>),
 }
 
+/// A content block within a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        content: ToolResultContent,
+    },
+    #[serde(rename = "thinking")]
+    Thinking {
+        thinking: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+    #[serde(rename = "image")]
+    Image { source: serde_json::Value },
+}
+
+/// Tool result content: either a plain string or nested content blocks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(untagged)]
+pub enum ToolResultContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Message {
     pub role: Role,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_calls: Option<Vec<ToolCall>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_call_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning_content: Option<String>,
-    #[serde(flatten, default)]
-    #[serde(skip_serializing_if = "serde_json::Map::is_empty")]
-    pub extra: serde_json::Map<String, serde_json::Value>,
+    pub content: Vec<ContentBlock>,
 }
 
 impl Message {
-    fn with_role(role: Role, content: impl Into<String>) -> Self {
+    pub fn user(content: impl Into<String>) -> Self {
         Self {
-            role,
-            content: Some(serde_json::Value::String(content.into())),
-            tool_calls: None,
-            tool_call_id: None,
-            name: None,
-            reasoning_content: None,
-            extra: serde_json::Map::new(),
+            role: Role::User,
+            content: vec![ContentBlock::Text { text: content.into() }],
         }
     }
 
-    /// Build a `Message` with role `User` and the given text content.
-    pub fn user(content: impl Into<String>) -> Self {
-        Self::with_role(Role::User, content)
-    }
-
-    /// Build a `Message` with role `Assistant` and the given text content.
     pub fn assistant(content: impl Into<String>) -> Self {
-        Self::with_role(Role::Assistant, content)
+        Self {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text { text: content.into() }],
+        }
     }
 
-    /// Build a `Message` with role `System` and the given text content.
     pub fn system(content: impl Into<String>) -> Self {
-        Self::with_role(Role::System, content)
+        Self {
+            role: Role::System,
+            content: vec![ContentBlock::Text { text: content.into() }],
+        }
     }
 
-    /// Build a `Message` with role `Tool`, setting `tool_call_id` and `name`.
     pub fn tool(
-        tool_call_id: impl Into<String>,
+        tool_use_id: impl Into<String>,
         name: impl Into<String>,
         content: impl Into<String>,
     ) -> Self {
-        let mut msg = Self::with_role(Role::Tool, content);
-        msg.tool_call_id = Some(tool_call_id.into());
-        msg.name = Some(name.into());
-        msg
+        Self {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.into(),
+                name: Some(name.into()),
+                content: ToolResultContent::Text(content.into()),
+            }],
+        }
     }
 
-    /// Return the text view of `content` when it is a non-empty JSON string.
-    ///
-    /// Returns `None` for `null`, empty strings, and non-string variants
-    /// (e.g. multimodal arrays).
+    /// Concatenated text from all Text blocks, or `None` if empty.
     pub fn content_str(&self) -> Option<&str> {
-        self.content
-            .as_ref()
-            .and_then(serde_json::Value::as_str)
-            .filter(|s| !s.is_empty())
+        for block in &self.content {
+            if let ContentBlock::Text { text } = block {
+                if !text.is_empty() {
+                    return Some(text.as_str());
+                }
+            }
+        }
+        None
+    }
+
+    /// Iterator over tool-use blocks.
+    pub fn tool_uses(&self) -> impl Iterator<Item = (&str, &str, &serde_json::Value)> {
+        self.content.iter().filter_map(|b| match b {
+            ContentBlock::ToolUse { id, name, input } => Some((id.as_str(), name.as_str(), input)),
+            _ => None,
+        })
+    }
+
+    /// The thinking content, if any.
+    pub fn thinking(&self) -> Option<&str> {
+        for block in &self.content {
+            if let ContentBlock::Thinking { thinking, .. } = block {
+                if !thinking.is_empty() {
+                    return Some(thinking.as_str());
+                }
+            }
+        }
+        None
     }
 }
 
@@ -347,30 +392,13 @@ impl ChatCompletionResponse {
     }
 
     /// Text content from the first choice's message, if non-empty.
-    ///
-    /// Empty strings collapse to `None` (via `Message::content_str`).
     pub fn content(&self) -> Option<&str> {
         self.choices.first()?.message.content_str()
     }
 
     /// Reasoning content from the first choice's message, if non-empty.
-    ///
-    /// Empty strings collapse to `None`.
     pub fn reasoning_content(&self) -> Option<&str> {
-        self.choices
-            .first()?
-            .message
-            .reasoning_content
-            .as_deref()
-            .filter(|s| !s.is_empty())
-    }
-
-    /// Tool calls from the first choice's message. Empty slice if none.
-    pub fn tool_calls(&self) -> &[ToolCall] {
-        self.choices
-            .first()
-            .and_then(|c| c.message.tool_calls.as_deref())
-            .unwrap_or(&[])
+        self.choices.first()?.message.thinking()
     }
 
     /// Finish reason from the first choice, if present.

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -1,13 +1,13 @@
 pub use anthropic::{
     AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
     AnthropicSystem, AnthropicTool, AnthropicUsage, DEFAULT_MAX_TOKENS, ThinkingConfig,
-    ToolResultContent,
 };
 pub use audio::AudioSpeechRequest;
 pub use chat::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice,
-    CompletionTokensDetails, Delta, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef,
-    Message, Role, Stop, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolType, Usage,
+    CompletionTokensDetails, ContentBlock, Delta, FinishReason, FunctionCall, FunctionCallDelta,
+    FunctionDef, Message, Role, Stop, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolResultContent,
+    ToolType, Usage,
 };
 pub use embedding::{
     Embedding, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,

--- a/crates/mlx/examples/tool_capability.rs
+++ b/crates/mlx/examples/tool_capability.rs
@@ -74,7 +74,8 @@ async fn main() {
     match provider.chat_completion(&req).await {
         Ok(resp) => {
             let msg = &resp.choices[0].message;
-            let text = msg.content.as_ref().and_then(|v| v.as_str()).unwrap_or("");
+            let text = msg.content_str().unwrap_or("");
+            let tool_uses: Vec<_> = msg.tool_uses().collect();
             let usage = resp.usage.as_ref();
             eprintln!(
                 "      {} prompt / {} completion tokens",
@@ -82,7 +83,7 @@ async fn main() {
                 usage.map(|u| u.completion_tokens).unwrap_or(0)
             );
             eprintln!("      finish_reason: {:?}", resp.choices[0].finish_reason);
-            eprintln!("      tool_calls: {:?}", msg.tool_calls);
+            eprintln!("      tool_calls: {tool_uses:?}");
             eprintln!("      content: {text:?}\n");
         }
         Err(e) => {

--- a/crates/mlx/examples/vlm_smoke.rs
+++ b/crates/mlx/examples/vlm_smoke.rs
@@ -15,9 +15,9 @@
 //! Usage: cargo run -p crabllm-mlx --example vlm_smoke
 
 use base64::{Engine, engine::general_purpose::STANDARD};
-use crabllm_core::{ChatCompletionRequest, Message, Provider, Role};
+use crabllm_core::{ChatCompletionRequest, ContentBlock, Message, Provider, Role};
 use crabllm_mlx::{DownloadEvent, MlxPool, MlxProvider, cached_model_path, download_model};
-use serde_json::{Value, json};
+use serde_json::json;
 use std::{error::Error, sync::Arc};
 
 const MODEL: &str = "mlx-community/Qwen3.5-0.8B-MLX-4bit";
@@ -76,19 +76,16 @@ fn ensure_downloaded() -> Result<(), Box<dyn Error>> {
 }
 
 async fn run_once(provider: &MlxProvider, label: &str, url: String) -> Result<(), Box<dyn Error>> {
-    let content: Value = json!([
-        {"type": "text", "text": PROMPT},
-        {"type": "image_url", "image_url": {"url": url}},
-    ]);
-
     let message = Message {
         role: Role::User,
-        content: Some(content),
-        tool_calls: None,
-        tool_call_id: None,
-        name: None,
-        reasoning_content: None,
-        extra: Default::default(),
+        content: vec![
+            ContentBlock::Text {
+                text: PROMPT.to_string(),
+            },
+            ContentBlock::Image {
+                source: json!({"type": "url", "url": url}),
+            },
+        ],
     };
 
     let request = ChatCompletionRequest {

--- a/crates/mlx/src/pool.rs
+++ b/crates/mlx/src/pool.rs
@@ -150,7 +150,7 @@ impl MlxPool {
 
     /// Evict a single model. Returns `true` if the slot was present
     /// before the call (i.e. something was actually unloaded).
-    pub(crate) fn evict(&self, model_dir: &str) -> bool {
+    pub fn evict(&self, model_dir: &str) -> bool {
         let Ok(c) = CString::new(model_dir) else {
             return false;
         };

--- a/crates/mlx/src/provider.rs
+++ b/crates/mlx/src/provider.rs
@@ -17,8 +17,8 @@ use crate::{
 };
 use crabllm_core::{
     BoxStream, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice,
-    ChunkChoice, Delta, Error, FinishReason, FunctionCall, FunctionCallDelta, Message, Provider,
-    Role, ToolCall, ToolCallDelta, ToolType, Usage,
+    ChunkChoice, ContentBlock, Delta, Error, FinishReason, FunctionCall, FunctionCallDelta,
+    Message, Provider, Role, ToolCall, ToolCallDelta, ToolType, Usage,
 };
 use futures::{channel::mpsc, stream::StreamExt};
 use std::{
@@ -166,6 +166,20 @@ impl Provider for MlxProvider {
             FinishReason::ToolCalls
         };
 
+        let mut blocks = Vec::new();
+        if !text.is_empty() {
+            blocks.push(ContentBlock::Text { text });
+        }
+        for tc in tool_calls {
+            let input = crabllm_core::json::from_str(&tc.function.arguments)
+                .unwrap_or(serde_json::Value::Object(Default::default()));
+            blocks.push(ContentBlock::ToolUse {
+                id: tc.id,
+                name: tc.function.name,
+                input,
+            });
+        }
+
         Ok(ChatCompletionResponse {
             id: new_completion_id(),
             object: "chat.completion".to_string(),
@@ -175,16 +189,7 @@ impl Provider for MlxProvider {
                 index: 0,
                 message: Message {
                     role: Role::Assistant,
-                    content: Some(serde_json::Value::String(text)),
-                    tool_calls: if tool_calls.is_empty() {
-                        None
-                    } else {
-                        Some(tool_calls)
-                    },
-                    tool_call_id: None,
-                    name: None,
-                    reasoning_content: None,
-                    extra: serde_json::Map::new(),
+                    content: blocks,
                 },
                 finish_reason: Some(finish_reason),
                 logprobs: None,

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -286,7 +286,11 @@ impl Provider for RemoteProvider {
                 api_key,
             } => {
                 let s = provider::anthropic::chat_completion_stream(
-                    client, base_url, api_key, request, &request.model,
+                    client,
+                    base_url,
+                    api_key,
+                    request,
+                    &request.model,
                 )
                 .await?;
                 Ok(s.boxed())
@@ -297,9 +301,13 @@ impl Provider for RemoteProvider {
                 api_key,
                 ..
             } => {
-                let s =
-                    provider::openai::chat_completion_stream(client, openai_base_url, api_key, request)
-                        .await?;
+                let s = provider::openai::chat_completion_stream(
+                    client,
+                    openai_base_url,
+                    api_key,
+                    request,
+                )
+                .await?;
                 Ok(s.boxed())
             }
             RemoteProvider::Google { client, api_key } => {
@@ -488,7 +496,9 @@ impl Provider for RemoteProvider {
     fn is_openai_compat(&self) -> bool {
         matches!(
             self,
-            RemoteProvider::Openai { .. } | RemoteProvider::Azure { .. } | RemoteProvider::Deepseek { .. }
+            RemoteProvider::Openai { .. }
+                | RemoteProvider::Azure { .. }
+                | RemoteProvider::Deepseek { .. }
         )
     }
 

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -37,7 +37,11 @@ pub enum RemoteProvider {
         api_key: String,
     },
     /// Anthropic Messages API. Requires request/response translation.
-    Anthropic { client: HttpClient, api_key: String },
+    Anthropic {
+        client: HttpClient,
+        base_url: String,
+        api_key: String,
+    },
     /// Google Gemini API. Requires request/response translation.
     Google { client: HttpClient, api_key: String },
     /// AWS Bedrock. Requires SigV4 signing + translation.
@@ -69,8 +73,8 @@ pub fn make_client() -> HttpClient {
 ///
 /// Only the OpenAI-shaped endpoints are stripped: `/chat/completions`,
 /// `/embeddings`, `/audio/transcriptions`, `/audio/speech`,
-/// `/images/generations`. Anthropic, Google, and Bedrock don't take a
-/// `base_url` field at all, so this function is never called for them.
+/// `/images/generations`. Anthropic appends `/messages` itself, so
+/// stripping is not needed there.
 fn normalize_base_url(url: &str) -> String {
     let url = url.trim_end_matches('/');
     for suffix in [
@@ -112,6 +116,10 @@ impl RemoteProvider {
             },
             ProviderKind::Anthropic => RemoteProvider::Anthropic {
                 client,
+                base_url: config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| provider::anthropic::DEFAULT_BASE_URL.to_string()),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
             ProviderKind::Google => RemoteProvider::Google {
@@ -198,9 +206,11 @@ impl Provider for RemoteProvider {
                 base_url,
                 api_key,
             } => provider::openai::chat_completion(client, base_url, api_key, request).await,
-            RemoteProvider::Anthropic { client, api_key } => {
-                provider::anthropic::chat_completion(client, api_key, request).await
-            }
+            RemoteProvider::Anthropic {
+                client,
+                base_url,
+                api_key,
+            } => provider::anthropic::chat_completion(client, base_url, api_key, request).await,
             RemoteProvider::Google { client, api_key } => {
                 provider::google::chat_completion(client, api_key, request).await
             }
@@ -243,12 +253,13 @@ impl Provider for RemoteProvider {
                         .await?;
                 Ok(s.boxed())
             }
-            RemoteProvider::Anthropic { client, api_key } => {
+            RemoteProvider::Anthropic {
+                client,
+                base_url,
+                api_key,
+            } => {
                 let s = provider::anthropic::chat_completion_stream(
-                    client,
-                    api_key,
-                    request,
-                    &request.model,
+                    client, base_url, api_key, request, &request.model,
                 )
                 .await?;
                 Ok(s.boxed())
@@ -469,8 +480,13 @@ impl Provider for RemoteProvider {
 
     async fn anthropic_messages_raw(&self, raw_body: Bytes) -> Result<Bytes, Error> {
         match self {
-            RemoteProvider::Anthropic { client, api_key } => {
-                provider::anthropic::anthropic_messages_raw(client, api_key, raw_body).await
+            RemoteProvider::Anthropic {
+                client,
+                base_url,
+                api_key,
+            } => {
+                provider::anthropic::anthropic_messages_raw(client, base_url, api_key, raw_body)
+                    .await
             }
             _ => Err(Error::not_implemented("anthropic_messages_raw")),
         }

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -42,6 +42,14 @@ pub enum RemoteProvider {
         base_url: String,
         api_key: String,
     },
+    /// DeepSeek API — dual-compatible: OpenAI-format at `openai_base_url`,
+    /// Anthropic-format at `anthropic_base_url`. Both use Bearer auth.
+    Deepseek {
+        client: HttpClient,
+        openai_base_url: String,
+        anthropic_base_url: String,
+        api_key: String,
+    },
     /// Google Gemini API. Requires request/response translation.
     Google { client: HttpClient, api_key: String },
     /// AWS Bedrock. Requires SigV4 signing + translation.
@@ -122,6 +130,19 @@ impl RemoteProvider {
                     .unwrap_or_else(|| provider::anthropic::DEFAULT_BASE_URL.to_string()),
                 api_key: config.api_key.clone().unwrap_or_default(),
             },
+            ProviderKind::Deepseek => {
+                let base = config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| provider::deepseek::DEFAULT_BASE_URL.to_string());
+                let base = base.trim_end_matches('/');
+                RemoteProvider::Deepseek {
+                    client,
+                    openai_base_url: normalize_base_url(&format!("{base}/v1")),
+                    anthropic_base_url: format!("{base}/anthropic"),
+                    api_key: config.api_key.clone().unwrap_or_default(),
+                }
+            }
             ProviderKind::Google => RemoteProvider::Google {
                 client,
                 api_key: config.api_key.clone().unwrap_or_default(),
@@ -211,6 +232,12 @@ impl Provider for RemoteProvider {
                 base_url,
                 api_key,
             } => provider::anthropic::chat_completion(client, base_url, api_key, request).await,
+            RemoteProvider::Deepseek {
+                client,
+                openai_base_url,
+                api_key,
+                ..
+            } => provider::openai::chat_completion(client, openai_base_url, api_key, request).await,
             RemoteProvider::Google { client, api_key } => {
                 provider::google::chat_completion(client, api_key, request).await
             }
@@ -262,6 +289,17 @@ impl Provider for RemoteProvider {
                     client, base_url, api_key, request, &request.model,
                 )
                 .await?;
+                Ok(s.boxed())
+            }
+            RemoteProvider::Deepseek {
+                client,
+                openai_base_url,
+                api_key,
+                ..
+            } => {
+                let s =
+                    provider::openai::chat_completion_stream(client, openai_base_url, api_key, request)
+                        .await?;
                 Ok(s.boxed())
             }
             RemoteProvider::Google { client, api_key } => {
@@ -323,6 +361,12 @@ impl Provider for RemoteProvider {
             RemoteProvider::Anthropic { .. } => {
                 Err(provider::anthropic::not_implemented("embedding"))
             }
+            RemoteProvider::Deepseek {
+                client,
+                openai_base_url,
+                api_key,
+                ..
+            } => provider::openai::embedding(client, openai_base_url, api_key, request).await,
             RemoteProvider::Google { .. } => Err(provider::google::not_implemented("embedding")),
             RemoteProvider::Bedrock { .. } => Err(provider::bedrock::not_implemented("embedding")),
             RemoteProvider::Azure {
@@ -343,6 +387,9 @@ impl Provider for RemoteProvider {
             } => provider::openai::image_generation(client, base_url, api_key, request).await,
             RemoteProvider::Anthropic { .. } => {
                 Err(provider::anthropic::not_implemented("image_generation"))
+            }
+            RemoteProvider::Deepseek { .. } => {
+                Err(provider::deepseek::not_implemented("image_generation"))
             }
             RemoteProvider::Google { .. } => {
                 Err(provider::google::not_implemented("image_generation"))
@@ -371,6 +418,9 @@ impl Provider for RemoteProvider {
             } => provider::openai::audio_speech(client, base_url, api_key, request).await,
             RemoteProvider::Anthropic { .. } => {
                 Err(provider::anthropic::not_implemented("audio_speech"))
+            }
+            RemoteProvider::Deepseek { .. } => {
+                Err(provider::deepseek::not_implemented("audio_speech"))
             }
             RemoteProvider::Google { .. } => Err(provider::google::not_implemented("audio_speech")),
             RemoteProvider::Bedrock { .. } => {
@@ -405,6 +455,9 @@ impl Provider for RemoteProvider {
             RemoteProvider::Anthropic { .. } => {
                 Err(provider::anthropic::not_implemented("audio_transcription"))
             }
+            RemoteProvider::Deepseek { .. } => {
+                Err(provider::deepseek::not_implemented("audio_transcription"))
+            }
             RemoteProvider::Google { .. } => {
                 Err(provider::google::not_implemented("audio_transcription"))
             }
@@ -435,7 +488,7 @@ impl Provider for RemoteProvider {
     fn is_openai_compat(&self) -> bool {
         matches!(
             self,
-            RemoteProvider::Openai { .. } | RemoteProvider::Azure { .. }
+            RemoteProvider::Openai { .. } | RemoteProvider::Azure { .. } | RemoteProvider::Deepseek { .. }
         )
     }
 
@@ -462,6 +515,15 @@ impl Provider for RemoteProvider {
                 )
                 .await
             }
+            RemoteProvider::Deepseek {
+                client,
+                openai_base_url,
+                api_key,
+                ..
+            } => {
+                provider::openai::chat_completion_raw(client, openai_base_url, api_key, raw_body)
+                    .await
+            }
             _ => {
                 let request: ChatCompletionRequest = crabllm_core::json::from_slice(&raw_body)
                     .map_err(|e| Error::Internal(e.to_string()))?;
@@ -475,7 +537,10 @@ impl Provider for RemoteProvider {
     }
 
     fn is_anthropic_compat(&self) -> bool {
-        matches!(self, RemoteProvider::Anthropic { .. })
+        matches!(
+            self,
+            RemoteProvider::Anthropic { .. } | RemoteProvider::Deepseek { .. }
+        )
     }
 
     async fn anthropic_messages_raw(&self, raw_body: Bytes) -> Result<Bytes, Error> {
@@ -487,6 +552,20 @@ impl Provider for RemoteProvider {
             } => {
                 provider::anthropic::anthropic_messages_raw(client, base_url, api_key, raw_body)
                     .await
+            }
+            RemoteProvider::Deepseek {
+                client,
+                anthropic_base_url,
+                api_key,
+                ..
+            } => {
+                provider::deepseek::anthropic_messages_raw(
+                    client,
+                    anthropic_base_url,
+                    api_key,
+                    raw_body,
+                )
+                .await
             }
             _ => Err(Error::not_implemented("anthropic_messages_raw")),
         }

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -650,4 +650,3 @@ fn anthropic_sse_stream(
         },
     )
 }
-

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -11,7 +11,7 @@ use crabllm_core::{
 use futures::stream::{self, Stream};
 use serde::Deserialize;
 
-const BASE_URL: &str = "https://api.anthropic.com/v1";
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
 const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
 const OAUTH_BETA: &str = "oauth-2025-04-20";
 
@@ -252,10 +252,11 @@ fn auth_headers(api_key: &str) -> Vec<(&'static str, String)> {
 /// returning the response bytes without deserialization.
 pub async fn anthropic_messages_raw(
     client: &HttpClient,
+    base_url: &str,
     api_key: &str,
     raw_body: Bytes,
 ) -> Result<Bytes, Error> {
-    let url = format!("{BASE_URL}/messages");
+    let url = format!("{}/messages", base_url.trim_end_matches('/'));
     let auth = auth_headers(api_key);
     let mut headers: Vec<(&str, &str)> = vec![
         ("anthropic-version", "2023-06-01"),
@@ -282,6 +283,7 @@ pub async fn anthropic_messages_raw(
 
 pub async fn chat_completion(
     client: &HttpClient,
+    base_url: &str,
     api_key: &str,
     request: &ChatCompletionRequest,
 ) -> Result<ChatCompletionResponse, Error> {
@@ -292,7 +294,7 @@ pub async fn chat_completion(
     }
 
     let anthropic_req = translate_request(request);
-    let url = format!("{BASE_URL}/messages");
+    let url = format!("{}/messages", base_url.trim_end_matches('/'));
 
     let body =
         crabllm_core::json::to_vec(&anthropic_req).map_err(|e| Error::Internal(e.to_string()))?;
@@ -328,13 +330,14 @@ pub async fn chat_completion(
 
 pub async fn chat_completion_stream(
     client: &HttpClient,
+    base_url: &str,
     api_key: &str,
     request: &ChatCompletionRequest,
     model: &str,
 ) -> Result<impl Stream<Item = Result<ChatCompletionChunk, Error>> + use<>, Error> {
     let mut anthropic_req = translate_request(request);
     anthropic_req.stream = Some(true);
-    let url = format!("{BASE_URL}/messages");
+    let url = format!("{}/messages", base_url.trim_end_matches('/'));
 
     let body =
         crabllm_core::json::to_vec(&anthropic_req).map_err(|e| Error::Internal(e.to_string()))?;

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -2,11 +2,11 @@ use crate::provider::schema;
 use crate::{ByteStream, HttpClient};
 use bytes::{Buf, Bytes, BytesMut};
 use crabllm_core::{
-    AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
-    AnthropicSystem, AnthropicTool, AnthropicUsage, ChatCompletionChunk, ChatCompletionRequest,
-    ChatCompletionResponse, Choice, ChunkChoice, DEFAULT_MAX_TOKENS, Delta, Error, FinishReason,
-    FunctionCall, FunctionCallDelta, Message, Role, Stop, ThinkingConfig, ToolCall, ToolCallDelta,
-    ToolChoice, ToolResultContent, ToolType, Usage,
+    AnthropicContent, AnthropicMessage, AnthropicRequest, AnthropicResponse, AnthropicSystem,
+    AnthropicTool, AnthropicUsage, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, Choice, ChunkChoice, ContentBlock, DEFAULT_MAX_TOKENS, Delta, Error,
+    FinishReason, FunctionCallDelta, Message, Role, Stop, ThinkingConfig, ToolCallDelta, ToolChoice,
+    ToolType, Usage,
 };
 use futures::{
     TryStreamExt, pin_mut,
@@ -85,116 +85,15 @@ fn translate_request(request: &ChatCompletionRequest) -> AnthropicRequest {
 
     for msg in &request.messages {
         if msg.role == Role::System {
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-            {
-                system_parts.push(s.to_string());
-            }
-        } else if msg.role == Role::Tool {
-            // Tool result → user message with tool_result content block.
-            let content_str = msg
-                .content
-                .as_ref()
-                .map(|c| {
-                    if let Some(s) = c.as_str() {
-                        s.to_string()
-                    } else {
-                        c.to_string()
-                    }
-                })
-                .unwrap_or_default();
-            let tool_use_id = msg.tool_call_id.clone().unwrap_or_default();
-            messages.push(AnthropicMessage {
-                role: "user".to_string(),
-                content: AnthropicContent::Blocks(vec![AnthropicContentBlock::ToolResult {
-                    tool_use_id,
-                    content: ToolResultContent::Text(content_str),
-                }]),
-            });
-        } else if msg.role == Role::Assistant
-            && let Some(tool_calls) = &msg.tool_calls
-        {
-            // Assistant message with tool_calls → content blocks.
-            let mut blocks = Vec::new();
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-                && !s.is_empty()
-            {
-                blocks.push(AnthropicContentBlock::Text {
-                    text: s.to_string(),
-                });
-            }
-            for tc in tool_calls {
-                let input = crabllm_core::json::from_str(&tc.function.arguments)
-                    .unwrap_or(serde_json::Value::Object(Default::default()));
-                blocks.push(AnthropicContentBlock::ToolUse {
-                    id: tc.id.clone(),
-                    name: tc.function.name.clone(),
-                    input,
-                });
-            }
-            messages.push(AnthropicMessage {
-                role: "assistant".to_string(),
-                content: AnthropicContent::Blocks(blocks),
-            });
-        } else {
-            let anthropic_content = match msg.content.as_ref() {
-                Some(c) if c.is_array() => {
-                    let mut blocks = Vec::new();
-                    if let Some(parts) = c.as_array() {
-                        for part in parts {
-                            match part.get("type").and_then(|t| t.as_str()) {
-                                Some("text") => {
-                                    if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                        blocks.push(AnthropicContentBlock::Text {
-                                            text: text.to_string(),
-                                        });
-                                    }
-                                }
-                                Some("image_url") => {
-                                    if let Some(url) = part
-                                        .get("image_url")
-                                        .and_then(|iu| iu.get("url"))
-                                        .and_then(|u| u.as_str())
-                                    {
-                                        let source = if let Some(rest) = url.strip_prefix("data:") {
-                                            // data:image/png;base64,<data>
-                                            let (meta, data) = rest.split_once(',').unwrap_or((
-                                                "application/octet-stream;base64",
-                                                rest,
-                                            ));
-                                            let media_type =
-                                                meta.strip_suffix(";base64").unwrap_or(meta);
-                                            serde_json::json!({
-                                                "type": "base64",
-                                                "media_type": media_type,
-                                                "data": data,
-                                            })
-                                        } else {
-                                            serde_json::json!({
-                                                "type": "url",
-                                                "url": url,
-                                            })
-                                        };
-                                        blocks.push(AnthropicContentBlock::Image { source });
-                                    }
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-                    if blocks.is_empty() {
-                        AnthropicContent::Text(String::new())
-                    } else {
-                        AnthropicContent::Blocks(blocks)
-                    }
+            for block in &msg.content {
+                if let ContentBlock::Text { text } = block {
+                    system_parts.push(text.clone());
                 }
-                Some(c) => AnthropicContent::Text(c.as_str().unwrap_or("").to_string()),
-                None => AnthropicContent::Text(String::new()),
-            };
+            }
+        } else {
             messages.push(AnthropicMessage {
                 role: msg.role.as_str().to_string(),
-                content: anthropic_content,
+                content: AnthropicContent::Blocks(msg.content.clone()),
             });
         }
     }
@@ -310,46 +209,6 @@ fn map_stop_reason(stop_reason: &Option<String>) -> Option<FinishReason> {
 }
 
 fn translate_response(resp: AnthropicResponse) -> ChatCompletionResponse {
-    let mut content_text = String::new();
-    let mut tool_calls = Vec::new();
-    let mut reasoning_content = None;
-
-    for block in resp.content {
-        match block {
-            AnthropicContentBlock::Text { text } => content_text.push_str(&text),
-            AnthropicContentBlock::Thinking { thinking, .. } => {
-                if !thinking.is_empty() {
-                    reasoning_content = Some(thinking);
-                }
-            }
-            AnthropicContentBlock::ToolUse { id, name, input } => {
-                tool_calls.push(ToolCall {
-                    index: None,
-                    id,
-                    kind: ToolType::Function,
-                    function: FunctionCall {
-                        name,
-                        arguments: crabllm_core::json::to_string(&input).unwrap_or_default(),
-                    },
-                });
-            }
-            // Image and ToolResult do not appear in assistant responses.
-            AnthropicContentBlock::Image { .. } | AnthropicContentBlock::ToolResult { .. } => {}
-        }
-    }
-
-    let tool_calls_opt = if tool_calls.is_empty() {
-        None
-    } else {
-        Some(tool_calls)
-    };
-
-    let content = if content_text.is_empty() && tool_calls_opt.is_some() {
-        None
-    } else {
-        Some(serde_json::Value::String(content_text))
-    };
-
     ChatCompletionResponse {
         id: resp.id,
         object: "chat.completion".to_string(),
@@ -359,12 +218,7 @@ fn translate_response(resp: AnthropicResponse) -> ChatCompletionResponse {
             index: 0,
             message: Message {
                 role: Role::Assistant,
-                content,
-                tool_calls: tool_calls_opt,
-                tool_call_id: None,
-                name: None,
-                reasoning_content,
-                extra: Default::default(),
+                content: resp.content,
             },
             finish_reason: map_stop_reason(&resp.stop_reason),
             logprobs: None,
@@ -808,9 +662,7 @@ async fn accumulate_stream(
     let mut id = String::new();
     let mut model = String::new();
     let mut created = 0u64;
-    let mut content = String::new();
-    let mut reasoning = String::new();
-    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut blocks: Vec<ContentBlock> = Vec::new();
     let mut finish_reason = None;
     let mut usage = None;
 
@@ -827,58 +679,63 @@ async fn accumulate_stream(
             if choice.finish_reason.is_some() {
                 finish_reason.clone_from(&choice.finish_reason);
             }
-            if let Some(ref text) = choice.delta.content {
-                content.push_str(text);
+            if let Some(ref text) = choice.delta.reasoning_content
+                && !text.is_empty()
+            {
+                match blocks.last_mut() {
+                    Some(ContentBlock::Thinking { thinking, .. }) => thinking.push_str(text),
+                    _ => blocks.push(ContentBlock::Thinking {
+                        thinking: text.clone(),
+                        signature: None,
+                    }),
+                }
             }
-            if let Some(ref text) = choice.delta.reasoning_content {
-                reasoning.push_str(text);
+            if let Some(ref text) = choice.delta.content
+                && !text.is_empty()
+            {
+                match blocks.last_mut() {
+                    Some(ContentBlock::Text { text: existing }) => existing.push_str(text),
+                    _ => blocks.push(ContentBlock::Text { text: text.clone() }),
+                }
             }
             if let Some(ref deltas) = choice.delta.tool_calls {
                 for delta in deltas {
-                    let idx = delta.index as usize;
-                    if idx >= tool_calls.len() {
-                        tool_calls.push(ToolCall {
-                            index: None,
-                            id: delta.id.clone().unwrap_or_default(),
-                            kind: delta.kind.unwrap_or_default(),
-                            function: FunctionCall {
-                                name: delta
-                                    .function
-                                    .as_ref()
-                                    .and_then(|f| f.name.clone())
-                                    .unwrap_or_default(),
-                                arguments: delta
-                                    .function
-                                    .as_ref()
-                                    .and_then(|f| f.arguments.clone())
-                                    .unwrap_or_default(),
-                            },
+                    let has_id = delta.id.as_ref().is_some_and(|id| !id.is_empty());
+                    if has_id {
+                        let tc_id = delta.id.clone().unwrap_or_default();
+                        let name = delta
+                            .function
+                            .as_ref()
+                            .and_then(|f| f.name.clone())
+                            .unwrap_or_default();
+                        let args = delta
+                            .function
+                            .as_ref()
+                            .and_then(|f| f.arguments.clone())
+                            .unwrap_or_default();
+                        blocks.push(ContentBlock::ToolUse {
+                            id: tc_id,
+                            name,
+                            input: crabllm_core::json::from_str(&args)
+                                .unwrap_or(serde_json::Value::Object(Default::default())),
                         });
                     } else if let Some(ref f) = delta.function
                         && let Some(ref args) = f.arguments
                     {
-                        tool_calls[idx].function.arguments.push_str(args);
+                        if let Some(ContentBlock::ToolUse { input, .. }) = blocks.last_mut() {
+                            if let serde_json::Value::Object(_) = input {
+                                let existing = crabllm_core::json::to_string(input)
+                                    .unwrap_or_default();
+                                let combined = format!("{existing}{args}");
+                                *input = crabllm_core::json::from_str(&combined)
+                                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                            }
+                        }
                     }
                 }
             }
         }
     }
-
-    let tool_calls_opt = if tool_calls.is_empty() {
-        None
-    } else {
-        Some(tool_calls)
-    };
-    let msg_content = if content.is_empty() && tool_calls_opt.is_some() {
-        None
-    } else {
-        Some(serde_json::Value::String(content))
-    };
-    let reasoning_content = if reasoning.is_empty() {
-        None
-    } else {
-        Some(reasoning)
-    };
 
     Ok(ChatCompletionResponse {
         id,
@@ -889,12 +746,7 @@ async fn accumulate_stream(
             index: 0,
             message: Message {
                 role: Role::Assistant,
-                content: msg_content,
-                tool_calls: tool_calls_opt,
-                tool_call_id: None,
-                name: None,
-                reasoning_content,
-                extra: Default::default(),
+                content: blocks,
             },
             finish_reason,
             logprobs: None,

--- a/crates/provider/src/provider/anthropic.rs
+++ b/crates/provider/src/provider/anthropic.rs
@@ -5,13 +5,10 @@ use crabllm_core::{
     AnthropicContent, AnthropicMessage, AnthropicRequest, AnthropicResponse, AnthropicSystem,
     AnthropicTool, AnthropicUsage, ChatCompletionChunk, ChatCompletionRequest,
     ChatCompletionResponse, Choice, ChunkChoice, ContentBlock, DEFAULT_MAX_TOKENS, Delta, Error,
-    FinishReason, FunctionCallDelta, Message, Role, Stop, ThinkingConfig, ToolCallDelta, ToolChoice,
-    ToolType, Usage,
+    FinishReason, FunctionCallDelta, Message, Role, Stop, ThinkingConfig, ToolCallDelta,
+    ToolChoice, ToolType, Usage,
 };
-use futures::{
-    TryStreamExt, pin_mut,
-    stream::{self, Stream},
-};
+use futures::stream::{self, Stream};
 use serde::Deserialize;
 
 const BASE_URL: &str = "https://api.anthropic.com/v1";
@@ -288,10 +285,10 @@ pub async fn chat_completion(
     api_key: &str,
     request: &ChatCompletionRequest,
 ) -> Result<ChatCompletionResponse, Error> {
-    // OAuth tokens must use the streaming endpoint.
     if is_oauth_token(api_key) {
-        let stream = chat_completion_stream(client, api_key, request, &request.model).await?;
-        return accumulate_stream(stream).await;
+        return Err(Error::Internal(
+            "OAuth tokens only support streaming; set stream: true".into(),
+        ));
     }
 
     let anthropic_req = translate_request(request);
@@ -651,107 +648,3 @@ fn anthropic_sse_stream(
     )
 }
 
-/// Collect a streaming response into a single [`ChatCompletionResponse`].
-///
-/// Assumes at least one chunk (Anthropic always sends `message_start`).
-async fn accumulate_stream(
-    stream: impl Stream<Item = Result<ChatCompletionChunk, Error>>,
-) -> Result<ChatCompletionResponse, Error> {
-    pin_mut!(stream);
-
-    let mut id = String::new();
-    let mut model = String::new();
-    let mut created = 0u64;
-    let mut blocks: Vec<ContentBlock> = Vec::new();
-    let mut finish_reason = None;
-    let mut usage = None;
-
-    while let Some(chunk) = stream.try_next().await? {
-        if id.is_empty() {
-            id = chunk.id;
-            model = chunk.model;
-            created = chunk.created;
-        }
-        if chunk.usage.is_some() {
-            usage = chunk.usage;
-        }
-        for choice in &chunk.choices {
-            if choice.finish_reason.is_some() {
-                finish_reason.clone_from(&choice.finish_reason);
-            }
-            if let Some(ref text) = choice.delta.reasoning_content
-                && !text.is_empty()
-            {
-                match blocks.last_mut() {
-                    Some(ContentBlock::Thinking { thinking, .. }) => thinking.push_str(text),
-                    _ => blocks.push(ContentBlock::Thinking {
-                        thinking: text.clone(),
-                        signature: None,
-                    }),
-                }
-            }
-            if let Some(ref text) = choice.delta.content
-                && !text.is_empty()
-            {
-                match blocks.last_mut() {
-                    Some(ContentBlock::Text { text: existing }) => existing.push_str(text),
-                    _ => blocks.push(ContentBlock::Text { text: text.clone() }),
-                }
-            }
-            if let Some(ref deltas) = choice.delta.tool_calls {
-                for delta in deltas {
-                    let has_id = delta.id.as_ref().is_some_and(|id| !id.is_empty());
-                    if has_id {
-                        let tc_id = delta.id.clone().unwrap_or_default();
-                        let name = delta
-                            .function
-                            .as_ref()
-                            .and_then(|f| f.name.clone())
-                            .unwrap_or_default();
-                        let args = delta
-                            .function
-                            .as_ref()
-                            .and_then(|f| f.arguments.clone())
-                            .unwrap_or_default();
-                        blocks.push(ContentBlock::ToolUse {
-                            id: tc_id,
-                            name,
-                            input: crabllm_core::json::from_str(&args)
-                                .unwrap_or(serde_json::Value::Object(Default::default())),
-                        });
-                    } else if let Some(ref f) = delta.function
-                        && let Some(ref args) = f.arguments
-                    {
-                        if let Some(ContentBlock::ToolUse { input, .. }) = blocks.last_mut() {
-                            if let serde_json::Value::Object(_) = input {
-                                let existing = crabllm_core::json::to_string(input)
-                                    .unwrap_or_default();
-                                let combined = format!("{existing}{args}");
-                                *input = crabllm_core::json::from_str(&combined)
-                                    .unwrap_or(serde_json::Value::Object(Default::default()));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(ChatCompletionResponse {
-        id,
-        object: "chat.completion".to_string(),
-        created,
-        model,
-        choices: vec![Choice {
-            index: 0,
-            message: Message {
-                role: Role::Assistant,
-                content: blocks,
-            },
-            finish_reason,
-            logprobs: None,
-        }],
-        usage,
-        system_fingerprint: None,
-    })
-}

--- a/crates/provider/src/provider/bedrock.rs
+++ b/crates/provider/src/provider/bedrock.rs
@@ -15,9 +15,9 @@ use crate::provider::schema;
 use crate::{ByteStream, HttpClient};
 #[cfg(feature = "provider-bedrock")]
 use crabllm_core::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, Delta,
-    FinishReason, FunctionCall, FunctionCallDelta, Message, Role, ToolCall, ToolCallDelta,
-    ToolType, Usage,
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice,
+    ContentBlock as CoreContentBlock, Delta, FinishReason, FunctionCallDelta, Message, Role,
+    ToolCallDelta, Usage,
 };
 #[cfg(feature = "provider-bedrock")]
 use futures::stream::{self, Stream};
@@ -165,68 +165,53 @@ fn translate_request(request: &ChatCompletionRequest) -> ConverseRequest {
 
     for msg in &request.messages {
         if msg.role == Role::System {
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-            {
-                system_blocks.push(SystemBlock {
-                    text: s.to_string(),
-                });
+            for block in &msg.content {
+                if let CoreContentBlock::Text { text } = block {
+                    system_blocks.push(SystemBlock { text: text.clone() });
+                }
             }
-        } else if msg.role == Role::Tool {
-            // Tool result → user message with toolResult content block.
-            let content_str = msg
-                .content
-                .as_ref()
-                .map(|c| {
-                    if let Some(s) = c.as_str() {
-                        s.to_string()
-                    } else {
-                        c.to_string()
-                    }
-                })
-                .unwrap_or_default();
-            let tool_use_id = msg.tool_call_id.clone().unwrap_or_default();
-            messages.push(ConverseMessage {
-                role: "user".to_string(),
-                content: vec![ContentBlock::ToolResult {
-                    tool_use_id,
-                    content: vec![ToolResultContent::Text(content_str)],
-                }],
-            });
-        } else if msg.role == Role::Assistant
-            && let Some(tool_calls) = &msg.tool_calls
-        {
-            // Assistant message with tool_calls → content blocks.
-            let mut blocks = Vec::new();
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-                && !s.is_empty()
-            {
-                blocks.push(ContentBlock::Text(s.to_string()));
-            }
-            for tc in tool_calls {
-                let input = crabllm_core::json::from_str(&tc.function.arguments)
-                    .unwrap_or(serde_json::Value::Object(Default::default()));
-                blocks.push(ContentBlock::ToolUse {
-                    tool_use_id: tc.id.clone(),
-                    name: tc.function.name.clone(),
-                    input,
-                });
-            }
-            messages.push(ConverseMessage {
-                role: "assistant".to_string(),
-                content: blocks,
-            });
         } else {
-            let text = msg
+            let blocks: Vec<ContentBlock> = msg
                 .content
-                .as_ref()
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string();
+                .iter()
+                .filter_map(|b| match b {
+                    CoreContentBlock::Text { text } => Some(ContentBlock::Text(text.clone())),
+                    CoreContentBlock::ToolUse { id, name, input } => {
+                        Some(ContentBlock::ToolUse {
+                            tool_use_id: id.clone(),
+                            name: name.clone(),
+                            input: input.clone(),
+                        })
+                    }
+                    CoreContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => {
+                        let text = match content {
+                            crabllm_core::ToolResultContent::Text(s) => s.clone(),
+                            crabllm_core::ToolResultContent::Blocks(blocks) => {
+                                blocks
+                                    .iter()
+                                    .filter_map(|b| match b {
+                                        CoreContentBlock::Text { text } => Some(text.as_str()),
+                                        _ => None,
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n")
+                            }
+                        };
+                        Some(ContentBlock::ToolResult {
+                            tool_use_id: tool_use_id.clone(),
+                            content: vec![ToolResultContent::Text(text)],
+                        })
+                    }
+                    _ => None,
+                })
+                .collect();
             messages.push(ConverseMessage {
                 role: msg.role.as_str().to_string(),
-                content: vec![ContentBlock::Text(text)],
+                content: blocks,
             });
         }
     }
@@ -292,44 +277,29 @@ fn map_stop_reason(stop_reason: &Option<String>) -> Option<FinishReason> {
 
 #[cfg(feature = "provider-bedrock")]
 fn translate_response(resp: ConverseResponse, model: &str) -> ChatCompletionResponse {
-    let mut content_text = String::new();
-    let mut tool_calls = Vec::new();
+    let mut blocks = Vec::new();
 
     if let Some(message) = &resp.output.message {
         for block in &message.content {
             match block {
-                ContentBlock::Text(t) => content_text.push_str(t),
+                ContentBlock::Text(t) => {
+                    blocks.push(CoreContentBlock::Text { text: t.clone() });
+                }
                 ContentBlock::ToolUse {
                     tool_use_id,
                     name,
                     input,
                 } => {
-                    tool_calls.push(ToolCall {
-                        index: None,
+                    blocks.push(CoreContentBlock::ToolUse {
                         id: tool_use_id.clone(),
-                        kind: ToolType::Function,
-                        function: FunctionCall {
-                            name: name.clone(),
-                            arguments: crabllm_core::json::to_string(input).unwrap_or_default(),
-                        },
+                        name: name.clone(),
+                        input: input.clone(),
                     });
                 }
                 ContentBlock::ToolResult { .. } => {}
             }
         }
     }
-
-    let tool_calls_opt = if tool_calls.is_empty() {
-        None
-    } else {
-        Some(tool_calls)
-    };
-
-    let content = if content_text.is_empty() && tool_calls_opt.is_some() {
-        None
-    } else {
-        Some(serde_json::Value::String(content_text))
-    };
 
     ChatCompletionResponse {
         id: String::new(),
@@ -340,12 +310,7 @@ fn translate_response(resp: ConverseResponse, model: &str) -> ChatCompletionResp
             index: 0,
             message: Message {
                 role: Role::Assistant,
-                content,
-                tool_calls: tool_calls_opt,
-                tool_call_id: None,
-                name: None,
-                reasoning_content: None,
-                extra: Default::default(),
+                content: blocks,
             },
             finish_reason: map_stop_reason(&resp.stop_reason),
             logprobs: None,

--- a/crates/provider/src/provider/bedrock.rs
+++ b/crates/provider/src/provider/bedrock.rs
@@ -176,13 +176,11 @@ fn translate_request(request: &ChatCompletionRequest) -> ConverseRequest {
                 .iter()
                 .filter_map(|b| match b {
                     CoreContentBlock::Text { text } => Some(ContentBlock::Text(text.clone())),
-                    CoreContentBlock::ToolUse { id, name, input } => {
-                        Some(ContentBlock::ToolUse {
-                            tool_use_id: id.clone(),
-                            name: name.clone(),
-                            input: input.clone(),
-                        })
-                    }
+                    CoreContentBlock::ToolUse { id, name, input } => Some(ContentBlock::ToolUse {
+                        tool_use_id: id.clone(),
+                        name: name.clone(),
+                        input: input.clone(),
+                    }),
                     CoreContentBlock::ToolResult {
                         tool_use_id,
                         content,
@@ -190,16 +188,14 @@ fn translate_request(request: &ChatCompletionRequest) -> ConverseRequest {
                     } => {
                         let text = match content {
                             crabllm_core::ToolResultContent::Text(s) => s.clone(),
-                            crabllm_core::ToolResultContent::Blocks(blocks) => {
-                                blocks
-                                    .iter()
-                                    .filter_map(|b| match b {
-                                        CoreContentBlock::Text { text } => Some(text.as_str()),
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n")
-                            }
+                            crabllm_core::ToolResultContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| match b {
+                                    CoreContentBlock::Text { text } => Some(text.as_str()),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n"),
                         };
                         Some(ContentBlock::ToolResult {
                             tool_use_id: tool_use_id.clone(),

--- a/crates/provider/src/provider/deepseek.rs
+++ b/crates/provider/src/provider/deepseek.rs
@@ -1,0 +1,41 @@
+use crate::HttpClient;
+use bytes::Bytes;
+use crabllm_core::Error;
+
+pub const DEFAULT_BASE_URL: &str = "https://api.deepseek.com";
+
+pub fn not_implemented(name: &str) -> Error {
+    Error::Internal(format!("deepseek {name} not supported"))
+}
+
+/// Forward raw Anthropic-format JSON bytes to DeepSeek's Anthropic-
+/// compatible endpoint. Uses `Authorization: Bearer` (not `x-api-key`)
+/// because DeepSeek unifies auth across both endpoints.
+pub async fn anthropic_messages_raw(
+    client: &HttpClient,
+    base_url: &str,
+    api_key: &str,
+    raw_body: Bytes,
+) -> Result<Bytes, Error> {
+    let url = format!("{}/messages", base_url.trim_end_matches('/'));
+    let bearer = format!("Bearer {api_key}");
+    let headers = [
+        ("anthropic-version", "2023-06-01"),
+        ("content-type", "application/json"),
+        ("authorization", bearer.as_str()),
+    ];
+    let resp = client
+        .post(&url, &headers, raw_body)
+        .await
+        .map_err(|e| Error::Internal(e.to_string()))?;
+
+    if resp.status >= 400 {
+        let body = String::from_utf8_lossy(&resp.body).into_owned();
+        return Err(Error::Provider {
+            status: resp.status,
+            body,
+        });
+    }
+
+    Ok(resp.body)
+}

--- a/crates/provider/src/provider/google.rs
+++ b/crates/provider/src/provider/google.rs
@@ -2,9 +2,9 @@ use crate::provider::schema;
 use crate::{ByteStream, HttpClient};
 use bytes::{Buf, BytesMut};
 use crabllm_core::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, Delta,
-    Error, FinishReason, FunctionCall, FunctionCallDelta, Message, Role, ToolCall, ToolCallDelta,
-    ToolType, Usage,
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice,
+    ContentBlock, Delta, Error, FinishReason, FunctionCallDelta, Message, Role, ToolCallDelta,
+    ToolResultContent, Usage,
 };
 use futures::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
@@ -189,126 +189,108 @@ struct GeminiUsage {
 // ── Translation ──
 
 fn translate_request(request: &ChatCompletionRequest) -> GeminiRequest {
-    // Build tool_call_id → function_name index so Tool-role messages can
-    // resolve the function name even when msg.name is None.
+    // Build tool_use id → name index so ToolResult blocks can resolve the
+    // function name for Gemini's functionResponse.
     let mut tc_names = std::collections::HashMap::<&str, &str>::new();
     for msg in &request.messages {
-        if let Some(tool_calls) = &msg.tool_calls {
-            for tc in tool_calls {
-                tc_names.insert(&tc.id, &tc.function.name);
+        for block in &msg.content {
+            if let ContentBlock::ToolUse { id, name, .. } = block {
+                tc_names.insert(id.as_str(), name.as_str());
             }
         }
     }
 
     let mut system_parts = Vec::new();
     let mut contents = Vec::new();
+    let needs_skip_sentinel = is_gemini_3_or_newer(&request.model);
 
     for msg in &request.messages {
         if msg.role == Role::System {
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-            {
-                system_parts.push(GeminiPart {
-                    text: Some(s.to_string()),
-                    function_call: None,
-                    function_response: None,
-                    thought_signature: None,
-                });
+            for block in &msg.content {
+                if let ContentBlock::Text { text } = block {
+                    system_parts.push(GeminiPart {
+                        text: Some(text.clone()),
+                        function_call: None,
+                        function_response: None,
+                        thought_signature: None,
+                    });
+                }
             }
-        } else if msg.role == Role::Tool {
-            // Tool result → user message with functionResponse part.
-            // Prefer msg.name, fall back to looking up by tool_call_id.
-            let name = msg
-                .name
-                .clone()
-                .or_else(|| {
-                    msg.tool_call_id
-                        .as_deref()
-                        .and_then(|id| tc_names.get(id).map(|n| n.to_string()))
-                })
-                .unwrap_or_default();
-            let response_val = msg
-                .content
-                .as_ref()
-                .and_then(|c| {
-                    if c.is_object() || c.is_array() {
-                        Some(c.clone())
-                    } else if let Some(s) = c.as_str() {
-                        crabllm_core::json::from_str(s).ok()
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(serde_json::json!({"result": msg.content.as_ref().and_then(|c| c.as_str()).unwrap_or("")}));
-            contents.push(GeminiContent {
-                role: Some(GeminiRole::User),
-                parts: vec![GeminiPart {
-                    text: None,
-                    function_call: None,
-                    function_response: Some(GeminiFunctionResponse {
-                        name,
-                        response: response_val,
-                    }),
-                    thought_signature: None,
-                }],
-            });
-        } else if msg.role == Role::Assistant
-            && let Some(tool_calls) = &msg.tool_calls
-        {
-            // Assistant message with tool_calls → model message with functionCall parts.
-            let mut parts = Vec::new();
-            if let Some(content) = &msg.content
-                && let Some(s) = content.as_str()
-                && !s.is_empty()
-            {
-                parts.push(GeminiPart {
-                    text: Some(s.to_string()),
-                    function_call: None,
-                    function_response: None,
-                    thought_signature: None,
-                });
-            }
-            let needs_skip_sentinel = is_gemini_3_or_newer(&request.model);
-            for tc in tool_calls {
-                let args = crabllm_core::json::from_str(&tc.function.arguments)
-                    .unwrap_or(serde_json::Value::Object(Default::default()));
-                let signature = extract_signature_from_id(&tc.id)
-                    .map(|s| s.to_string())
-                    .or_else(|| needs_skip_sentinel.then(|| SKIP_VALIDATOR_SIGNATURE.to_string()));
-                parts.push(GeminiPart {
-                    text: None,
-                    function_call: Some(GeminiFunctionCall {
-                        name: tc.function.name.clone(),
-                        args,
-                    }),
-                    function_response: None,
-                    thought_signature: signature,
-                });
-            }
-            contents.push(GeminiContent {
-                role: Some(GeminiRole::Model),
-                parts,
-            });
         } else {
             let role = match msg.role {
                 Role::Assistant => GeminiRole::Model,
                 _ => GeminiRole::User,
             };
-            let text = msg
-                .content
-                .as_ref()
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string();
-            contents.push(GeminiContent {
-                role: Some(role),
-                parts: vec![GeminiPart {
-                    text: Some(text),
-                    function_call: None,
-                    function_response: None,
-                    thought_signature: None,
-                }],
-            });
+            let mut parts = Vec::new();
+            for block in &msg.content {
+                match block {
+                    ContentBlock::Text { text } if !text.is_empty() => {
+                        parts.push(GeminiPart {
+                            text: Some(text.clone()),
+                            function_call: None,
+                            function_response: None,
+                            thought_signature: None,
+                        });
+                    }
+                    ContentBlock::ToolUse { id, name, input } => {
+                        let signature = extract_signature_from_id(id)
+                            .map(|s| s.to_string())
+                            .or_else(|| {
+                                needs_skip_sentinel
+                                    .then(|| SKIP_VALIDATOR_SIGNATURE.to_string())
+                            });
+                        parts.push(GeminiPart {
+                            text: None,
+                            function_call: Some(GeminiFunctionCall {
+                                name: name.clone(),
+                                args: input.clone(),
+                            }),
+                            function_response: None,
+                            thought_signature: signature,
+                        });
+                    }
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        name,
+                        content,
+                    } => {
+                        let fn_name = name
+                            .as_deref()
+                            .or_else(|| tc_names.get(tool_use_id.as_str()).copied())
+                            .unwrap_or("")
+                            .to_string();
+                        let text = match content {
+                            ToolResultContent::Text(s) => s.clone(),
+                            ToolResultContent::Blocks(blocks) => blocks
+                                .iter()
+                                .filter_map(|b| match b {
+                                    ContentBlock::Text { text } => Some(text.as_str()),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        };
+                        let response_val = crabllm_core::json::from_str(&text)
+                            .unwrap_or(serde_json::json!({"result": text}));
+                        parts.push(GeminiPart {
+                            text: None,
+                            function_call: None,
+                            function_response: Some(GeminiFunctionResponse {
+                                name: fn_name,
+                                response: response_val,
+                            }),
+                            thought_signature: None,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            if !parts.is_empty() {
+                contents.push(GeminiContent {
+                    role: Some(role),
+                    parts,
+                });
+            }
         }
     }
 
@@ -400,56 +382,43 @@ impl From<GeminiUsage> for Usage {
     }
 }
 
-/// Extract text and tool calls from response candidate parts.
-fn extract_parts(candidate: &GeminiCandidate) -> (String, Vec<ToolCall>) {
-    let mut text = String::new();
-    let mut tool_calls = Vec::new();
+/// Extract content blocks from response candidate parts.
+fn extract_blocks(candidate: &GeminiCandidate) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
 
     if let Some(content) = &candidate.content {
         for (i, part) in content.parts.iter().enumerate() {
-            if let Some(t) = &part.text {
-                text.push_str(t);
+            if let Some(t) = &part.text
+                && !t.is_empty()
+            {
+                blocks.push(ContentBlock::Text { text: t.clone() });
             }
             if let Some(fc) = &part.function_call {
                 let base_id = format!("call_{i}");
                 let id = encode_signature_into_id(&base_id, part.thought_signature.as_deref());
-                tool_calls.push(ToolCall {
-                    index: None,
+                blocks.push(ContentBlock::ToolUse {
                     id,
-                    kind: ToolType::Function,
-                    function: FunctionCall {
-                        name: fc.name.clone(),
-                        arguments: crabllm_core::json::to_string(&fc.args).unwrap_or_default(),
-                    },
+                    name: fc.name.clone(),
+                    input: fc.args.clone(),
                 });
             }
         }
     }
 
-    (text, tool_calls)
+    blocks
 }
 
 fn translate_response(resp: GeminiResponse, model: &str) -> ChatCompletionResponse {
-    let (content_text, tool_calls, finish_reason) = resp
+    let (blocks, finish_reason) = resp
         .candidates
         .first()
         .map(|c| {
-            let (text, tcs) = extract_parts(c);
-            (text, tcs, c.finish_reason.as_ref().map(Into::into))
+            (
+                extract_blocks(c),
+                c.finish_reason.as_ref().map(Into::into),
+            )
         })
         .unwrap_or_default();
-
-    let tool_calls_opt = if tool_calls.is_empty() {
-        None
-    } else {
-        Some(tool_calls)
-    };
-
-    let content = if content_text.is_empty() && tool_calls_opt.is_some() {
-        None
-    } else {
-        Some(serde_json::Value::String(content_text))
-    };
 
     ChatCompletionResponse {
         id: String::new(),
@@ -460,12 +429,7 @@ fn translate_response(resp: GeminiResponse, model: &str) -> ChatCompletionRespon
             index: 0,
             message: Message {
                 role: Role::Assistant,
-                content,
-                tool_calls: tool_calls_opt,
-                tool_call_id: None,
-                name: None,
-                reasoning_content: None,
-                extra: Default::default(),
+                content: blocks,
             },
             finish_reason,
             logprobs: None,
@@ -588,11 +552,34 @@ fn gemini_sse_stream(
                         }
                     };
 
-                    let (text, tool_calls) = extract_parts(candidate);
+                    let blocks = extract_blocks(candidate);
                     let finish_reason = candidate.finish_reason.as_ref().map(Into::into);
 
+                    let mut text = String::new();
+                    let mut tool_call_deltas: Vec<ToolCallDelta> = Vec::new();
+                    for block in blocks {
+                        match block {
+                            ContentBlock::Text { text: t } => text.push_str(&t),
+                            ContentBlock::ToolUse { id, name, input } => {
+                                tool_call_deltas.push(ToolCallDelta {
+                                    index: tool_call_deltas.len() as u32,
+                                    id: Some(id),
+                                    kind: Some(crabllm_core::ToolType::Function),
+                                    function: Some(FunctionCallDelta {
+                                        name: Some(name),
+                                        arguments: Some(
+                                            crabllm_core::json::to_string(&input)
+                                                .unwrap_or_default(),
+                                        ),
+                                    }),
+                                });
+                            }
+                            _ => {}
+                        }
+                    }
+
                     let has_text = !text.is_empty();
-                    let has_tools = !tool_calls.is_empty();
+                    let has_tools = !tool_call_deltas.is_empty();
 
                     if !has_text && !has_tools && finish_reason.is_none() {
                         buffer.advance(newline_pos + 1);
@@ -603,21 +590,7 @@ fn gemini_sse_stream(
 
                     chunk_idx += 1;
                     let tool_call_deltas = if has_tools {
-                        Some(
-                            tool_calls
-                                .into_iter()
-                                .enumerate()
-                                .map(|(i, tc)| ToolCallDelta {
-                                    index: i as u32,
-                                    id: Some(tc.id),
-                                    kind: Some(ToolType::Function),
-                                    function: Some(FunctionCallDelta {
-                                        name: Some(tc.function.name),
-                                        arguments: Some(tc.function.arguments),
-                                    }),
-                                })
-                                .collect(),
-                        )
+                        Some(tool_call_deltas)
                     } else {
                         None
                     };

--- a/crates/provider/src/provider/google.rs
+++ b/crates/provider/src/provider/google.rs
@@ -236,8 +236,7 @@ fn translate_request(request: &ChatCompletionRequest) -> GeminiRequest {
                         let signature = extract_signature_from_id(id)
                             .map(|s| s.to_string())
                             .or_else(|| {
-                                needs_skip_sentinel
-                                    .then(|| SKIP_VALIDATOR_SIGNATURE.to_string())
+                                needs_skip_sentinel.then(|| SKIP_VALIDATOR_SIGNATURE.to_string())
                             });
                         parts.push(GeminiPart {
                             text: None,
@@ -412,12 +411,7 @@ fn translate_response(resp: GeminiResponse, model: &str) -> ChatCompletionRespon
     let (blocks, finish_reason) = resp
         .candidates
         .first()
-        .map(|c| {
-            (
-                extract_blocks(c),
-                c.finish_reason.as_ref().map(Into::into),
-            )
-        })
+        .map(|c| (extract_blocks(c), c.finish_reason.as_ref().map(Into::into)))
         .unwrap_or_default();
 
     ChatCompletionResponse {

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -1,7 +1,7 @@
 pub mod anthropic;
 pub mod azure;
-pub mod deepseek;
 pub mod bedrock;
+pub mod deepseek;
 pub mod google;
 pub mod openai;
 pub mod schema;

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod azure;
+pub mod deepseek;
 pub mod bedrock;
 pub mod google;
 pub mod openai;

--- a/crates/provider/src/registry.rs
+++ b/crates/provider/src/registry.rs
@@ -257,7 +257,7 @@ fn validate_provider(name: &str, config: &ProviderConfig) -> Result<(), Error> {
             // Both have a sensible default base_url; nothing to require.
             Ok(())
         }
-        ProviderKind::Anthropic | ProviderKind::Google => {
+        ProviderKind::Anthropic | ProviderKind::Deepseek | ProviderKind::Google => {
             if is_blank(&config.api_key) {
                 return Err(Error::Config(format!(
                     "provider '{name}' ({}) requires an api_key",

--- a/crates/proxy/src/anthropic/translate.rs
+++ b/crates/proxy/src/anthropic/translate.rs
@@ -16,8 +16,7 @@
 use crabllm_core::{
     AnthropicContent, AnthropicContentBlock, AnthropicMessage, AnthropicRequest, AnthropicResponse,
     AnthropicSystem, AnthropicTool, AnthropicUsage, ChatCompletionRequest, ChatCompletionResponse,
-    Error, FinishReason, FunctionCall, FunctionDef, Message, Role, Stop, Tool, ToolCall,
-    ToolChoice, ToolResultContent, ToolType, Usage,
+    Error, FinishReason, FunctionDef, Message, Role, Stop, Tool, ToolChoice, ToolType, Usage,
 };
 
 pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
@@ -79,159 +78,19 @@ pub fn to_chat_completion(req: AnthropicRequest) -> ChatCompletionRequest {
 }
 
 fn append_message(out: &mut Vec<Message>, msg: AnthropicMessage) {
-    let is_assistant = msg.role == "assistant";
-
+    let role = match msg.role.as_str() {
+        "assistant" => Role::Assistant,
+        "user" => Role::User,
+        _ => Role::Custom(msg.role),
+    };
     let blocks = match msg.content {
-        AnthropicContent::Text(s) => {
-            out.push(if is_assistant {
-                Message::assistant(s)
-            } else {
-                Message::user(s)
-            });
-            return;
-        }
+        AnthropicContent::Text(s) => vec![AnthropicContentBlock::Text { text: s }],
         AnthropicContent::Blocks(b) => b,
     };
-
-    if is_assistant {
-        out.push(assistant_from_blocks(blocks));
-    } else {
-        append_user_blocks(out, blocks);
-    }
-}
-
-/// Collapse an assistant block list into a single `Message`.
-///
-/// Anthropic assistant turns may carry interleaved thinking, text, and tool_use
-/// blocks. OpenAI's format has a flat `content` string + `tool_calls` array +
-/// `reasoning_content`, so we concatenate text, collect tool_use into
-/// tool_calls, and stash any thinking into reasoning_content.
-fn assistant_from_blocks(blocks: Vec<AnthropicContentBlock>) -> Message {
-    let mut text = String::new();
-    let mut tool_calls: Vec<ToolCall> = Vec::new();
-    let mut reasoning = String::new();
-
-    for block in blocks {
-        match block {
-            AnthropicContentBlock::Text { text: t } => text.push_str(&t),
-            AnthropicContentBlock::Thinking { thinking, .. } => reasoning.push_str(&thinking),
-            AnthropicContentBlock::ToolUse { id, name, input } => {
-                tool_calls.push(ToolCall {
-                    index: None,
-                    id,
-                    kind: ToolType::Function,
-                    function: FunctionCall {
-                        name,
-                        arguments: crabllm_core::json::to_string(&input)
-                            .unwrap_or_else(|_| "{}".into()),
-                    },
-                });
-            }
-            // Image/ToolResult are not valid on assistant turns.
-            AnthropicContentBlock::Image { .. } | AnthropicContentBlock::ToolResult { .. } => {}
-        }
-    }
-
-    let content = if text.is_empty() && !tool_calls.is_empty() {
-        None
-    } else {
-        Some(serde_json::Value::String(text))
-    };
-
-    Message {
-        role: Role::Assistant,
-        content,
-        tool_calls: if tool_calls.is_empty() {
-            None
-        } else {
-            Some(tool_calls)
-        },
-        tool_call_id: None,
-        name: None,
-        reasoning_content: if reasoning.is_empty() {
-            None
-        } else {
-            Some(reasoning)
-        },
-        extra: serde_json::Map::new(),
-    }
-}
-
-/// User turns may interleave text/image content and tool_result blocks. OpenAI
-/// splits these into distinct messages: a user message for text/image parts
-/// and a tool message per tool_result. Emit in original order so tool results
-/// stay positioned correctly relative to any follow-up user text.
-fn append_user_blocks(out: &mut Vec<Message>, blocks: Vec<AnthropicContentBlock>) {
-    let mut user_parts: Vec<serde_json::Value> = Vec::new();
-
-    for block in blocks {
-        match block {
-            AnthropicContentBlock::Text { text } => {
-                user_parts.push(serde_json::json!({"type": "text", "text": text}));
-            }
-            AnthropicContentBlock::Image { source } => {
-                if let Some(url) = image_source_to_url(&source) {
-                    user_parts.push(serde_json::json!({
-                        "type": "image_url",
-                        "image_url": {"url": url},
-                    }));
-                }
-            }
-            AnthropicContentBlock::ToolResult {
-                tool_use_id,
-                content,
-            } => {
-                flush_user_parts(out, &mut user_parts);
-                out.push(Message {
-                    role: Role::Tool,
-                    content: Some(serde_json::Value::String(tool_result_text(content))),
-                    tool_calls: None,
-                    tool_call_id: Some(tool_use_id),
-                    name: None,
-                    reasoning_content: None,
-                    extra: serde_json::Map::new(),
-                });
-            }
-            // Thinking/ToolUse are not valid on user turns.
-            AnthropicContentBlock::Thinking { .. } | AnthropicContentBlock::ToolUse { .. } => {}
-        }
-    }
-
-    flush_user_parts(out, &mut user_parts);
-}
-
-fn flush_user_parts(out: &mut Vec<Message>, parts: &mut Vec<serde_json::Value>) {
-    if parts.is_empty() {
-        return;
-    }
-    // If the only part is a text part, collapse to a plain string content so
-    // the OpenAI provider sees the simpler `content: "..."` shape.
-    let content =
-        if parts.len() == 1 && parts[0].get("type").and_then(|t| t.as_str()) == Some("text") {
-            parts[0]
-                .get("text")
-                .cloned()
-                .unwrap_or(serde_json::Value::String(String::new()))
-        } else {
-            serde_json::Value::Array(std::mem::take(parts))
-        };
-    parts.clear();
     out.push(Message {
-        role: Role::User,
-        content: Some(content),
-        tool_calls: None,
-        tool_call_id: None,
-        name: None,
-        reasoning_content: None,
-        extra: serde_json::Map::new(),
+        role,
+        content: blocks,
     });
-}
-
-fn tool_result_text(content: ToolResultContent) -> String {
-    match content {
-        ToolResultContent::Text(s) => s,
-        ToolResultContent::Blocks(blocks) => flatten_text_blocks(&blocks),
-    }
 }
 
 fn flatten_text_blocks(blocks: &[AnthropicContentBlock]) -> String {
@@ -245,22 +104,6 @@ fn flatten_text_blocks(blocks: &[AnthropicContentBlock]) -> String {
         }
     }
     out
-}
-
-fn image_source_to_url(source: &serde_json::Value) -> Option<String> {
-    let kind = source.get("type").and_then(|t| t.as_str())?;
-    match kind {
-        "base64" => {
-            let media_type = source.get("media_type").and_then(|t| t.as_str())?;
-            let data = source.get("data").and_then(|t| t.as_str())?;
-            Some(format!("data:{media_type};base64,{data}"))
-        }
-        "url" => source
-            .get("url")
-            .and_then(|u| u.as_str())
-            .map(str::to_string),
-        _ => None,
-    }
 }
 
 fn convert_tool(t: AnthropicTool) -> Tool {
@@ -319,7 +162,12 @@ pub fn from_chat_completion(resp: ChatCompletionResponse) -> Result<AnthropicRes
         .ok_or_else(|| Error::Internal("provider returned no usage".into()))?;
 
     let stop_reason = choice.finish_reason.as_ref().map(finish_reason_to_stop);
-    let content = message_to_blocks(choice.message);
+    let mut content = choice.message.content;
+    if content.is_empty() {
+        content.push(AnthropicContentBlock::Text {
+            text: String::new(),
+        });
+    }
 
     Ok(AnthropicResponse {
         id: resp.id,
@@ -331,49 +179,6 @@ pub fn from_chat_completion(resp: ChatCompletionResponse) -> Result<AnthropicRes
         stop_sequence: None,
         usage: usage_to_anthropic(usage),
     })
-}
-
-fn message_to_blocks(msg: Message) -> Vec<AnthropicContentBlock> {
-    let mut blocks = Vec::new();
-
-    if let Some(reasoning) = msg.reasoning_content
-        && !reasoning.is_empty()
-    {
-        blocks.push(AnthropicContentBlock::Thinking {
-            thinking: reasoning,
-            signature: None,
-        });
-    }
-
-    if let Some(text) = msg.content.as_ref().and_then(|v| v.as_str())
-        && !text.is_empty()
-    {
-        blocks.push(AnthropicContentBlock::Text {
-            text: text.to_string(),
-        });
-    }
-
-    if let Some(tool_calls) = msg.tool_calls {
-        for tc in tool_calls {
-            let input = crabllm_core::json::from_str(&tc.function.arguments)
-                .unwrap_or(serde_json::Value::Object(Default::default()));
-            blocks.push(AnthropicContentBlock::ToolUse {
-                id: tc.id,
-                name: tc.function.name,
-                input,
-            });
-        }
-    }
-
-    // Anthropic responses always carry at least one block; emit an empty text
-    // block rather than a bare empty array so SDKs don't choke.
-    if blocks.is_empty() {
-        blocks.push(AnthropicContentBlock::Text {
-            text: String::new(),
-        });
-    }
-
-    blocks
 }
 
 fn finish_reason_to_stop(reason: &FinishReason) -> String {

--- a/crates/proxy/src/openapi.rs
+++ b/crates/proxy/src/openapi.rs
@@ -1,9 +1,11 @@
 use crabllm_core::{
-    AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, Choice,
-    ChunkChoice, CompletionTokensDetails, Delta, Embedding, EmbeddingInput, EmbeddingRequest,
-    EmbeddingResponse, EmbeddingUsage, FinishReason, FunctionCall, FunctionCallDelta, FunctionDef,
-    ImageRequest, KeyRateLimit, Message, Model, ModelList, PricingConfig, ProviderKind, Role, Stop,
-    Tool, ToolCall, ToolCallDelta, ToolChoice, ToolType, Usage,
+    AnthropicContent, AnthropicMessage, AnthropicRequest, AnthropicResponse, AnthropicSystem,
+    AnthropicTool, AnthropicUsage, AudioSpeechRequest, ChatCompletionChunk,
+    ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, CompletionTokensDetails,
+    Delta, Embedding, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
+    FinishReason, FunctionCall, FunctionCallDelta, FunctionDef, ImageRequest, KeyRateLimit,
+    Message, Model, ModelList, PricingConfig, ProviderKind, Role, Stop, ThinkingConfig, Tool,
+    ToolCall, ToolCallDelta, ToolChoice, ToolType, Usage,
 };
 use utoipa::OpenApi;
 use utoipa::openapi::{
@@ -47,6 +49,14 @@ const TAG_INFRA: &str = "Infrastructure";
     FinishReason,
     ToolChoice,
     Stop,
+    AnthropicRequest,
+    AnthropicResponse,
+    AnthropicMessage,
+    AnthropicContent,
+    AnthropicSystem,
+    AnthropicTool,
+    AnthropicUsage,
+    ThinkingConfig,
     EmbeddingRequest,
     EmbeddingResponse,
     Embedding,
@@ -341,10 +351,16 @@ fn public_paths() -> Paths {
             "/v1/messages",
             PathItem::new(
                 HttpMethod::Post,
-                op(TAG_API, "Create a message (Anthropic format)").description(Some(
-                    "Anthropic-style messages endpoint. Body and response follow \
+                op(TAG_API, "Create a message (Anthropic format)")
+                    .description(Some(
+                        "Anthropic-style messages endpoint. Body and response follow \
                          the Anthropic Messages API; SSE is returned when stream=true.",
-                )),
+                    ))
+                    .request_body(Some(json_body("AnthropicRequest")))
+                    .responses(json_ok(
+                        "AnthropicResponse",
+                        "Message response (or SSE stream when stream=true)",
+                    )),
             ),
         )
         .path(

--- a/crates/proxy/src/openapi.rs
+++ b/crates/proxy/src/openapi.rs
@@ -1,11 +1,11 @@
 use crabllm_core::{
     AnthropicContent, AnthropicMessage, AnthropicRequest, AnthropicResponse, AnthropicSystem,
-    AnthropicTool, AnthropicUsage, AudioSpeechRequest, ChatCompletionChunk,
-    ChatCompletionRequest, ChatCompletionResponse, Choice, ChunkChoice, CompletionTokensDetails,
-    Delta, Embedding, EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage,
-    FinishReason, FunctionCall, FunctionCallDelta, FunctionDef, ImageRequest, KeyRateLimit,
-    Message, Model, ModelList, PricingConfig, ProviderKind, Role, Stop, ThinkingConfig, Tool,
-    ToolCall, ToolCallDelta, ToolChoice, ToolType, Usage,
+    AnthropicTool, AnthropicUsage, AudioSpeechRequest, ChatCompletionChunk, ChatCompletionRequest,
+    ChatCompletionResponse, Choice, ChunkChoice, CompletionTokensDetails, Delta, Embedding,
+    EmbeddingInput, EmbeddingRequest, EmbeddingResponse, EmbeddingUsage, FinishReason,
+    FunctionCall, FunctionCallDelta, FunctionDef, ImageRequest, KeyRateLimit, Message, Model,
+    ModelList, PricingConfig, ProviderKind, Role, Stop, ThinkingConfig, Tool, ToolCall,
+    ToolCallDelta, ToolChoice, ToolType, Usage,
 };
 use utoipa::OpenApi;
 use utoipa::openapi::{

--- a/crates/proxy/tests/usage_events.rs
+++ b/crates/proxy/tests/usage_events.rs
@@ -10,8 +10,8 @@ use axum::{
     http::{Request, StatusCode},
 };
 use crabllm_core::{
-    BoxFuture, BoxStream, ChatCompletionRequest, ChatCompletionResponse, Choice, Error,
-    FinishReason, GatewayConfig, KvPairs, Message, Prefix, Provider, Role, Storage, Usage,
+    BoxFuture, BoxStream, ChatCompletionRequest, ChatCompletionResponse, Choice, ContentBlock,
+    Error, FinishReason, GatewayConfig, KvPairs, Message, Prefix, Provider, Role, Storage, Usage,
 };
 use crabllm_provider::{Deployment, ProviderRegistry};
 use crabllm_proxy::{AppState, UsageEvent, router};
@@ -39,12 +39,7 @@ impl Provider for FakeProvider {
                 index: 0,
                 message: Message {
                     role: Role::Assistant,
-                    content: Some(serde_json::Value::String("hi".into())),
-                    tool_calls: None,
-                    tool_call_id: None,
-                    name: None,
-                    reasoning_content: None,
-                    extra: Default::default(),
+                    content: vec![ContentBlock::Text { text: "hi".into() }],
                 },
                 finish_reason: Some(FinishReason::Stop),
                 logprobs: None,


### PR DESCRIPTION
## Summary

- Replace flat `Message` fields (`content`, `tool_calls`, `tool_call_id`, `name`, `reasoning_content`, `extra`) with `Vec<ContentBlock>` — a single typed enum that models text, tool use, tool results, thinking, and images uniformly
- Add DeepSeek provider with dual OpenAI/Anthropic compatibility (routes reasoning models through Anthropic-style thinking, standard models through OpenAI)
- Fix `base_url` not being threaded through the Anthropic provider
- Remove broken `accumulate_stream` for Anthropic OAuth
- Expose `MlxPool::evict` for explicit model unload
- Fix all clippy warnings for publish readiness

## Test plan

- [ ] `cargo clippy --all-targets` passes with zero warnings
- [ ] `cargo test` passes
- [ ] Verify DeepSeek provider routes requests correctly for both reasoning and standard models
- [ ] Verify Anthropic provider respects custom `base_url`
- [ ] Verify MLX examples (`tool_capability`, `vlm_smoke`) compile and run on Apple Silicon